### PR TITLE
support thread pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ url = "0.2.36"
 num = "0.1"
 rand = "0.3"
 log = "0.3"
+threadpool = "1.3"
 
 [dev-dependencies]
 quickcheck = "0.2.27"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ extern crate mio;
 extern crate url;
 extern crate num;
 extern crate rand;
+extern crate threadpool;
 #[cfg(test)]
 extern crate quickcheck;
 


### PR DESCRIPTION
1. The worker pool is added back to this library. This would be useful for some long time function. I will do the benchmark later.
2. I found this in [the mio's doc](https://github.com/carllerche/mio/blob/getting-started/doc/getting-started.md): `Even if we just received a ready notification, there is no guarantee that a read from the socket will succeed and not return Ok(None)`. So I put the packet back to the queue when `send_to` return `Ok(None)`.