### PR TITLE
Added ContentFormat support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ num = "0.1"
 rand = "0.3"
 log = "0.3"
 threadpool = "1.3"
+enum_primitive = "0.1.1"
 
 [dev-dependencies]
 quickcheck = "0.2.27"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,8 @@ extern crate url;
 extern crate num;
 extern crate rand;
 extern crate threadpool;
+#[macro_use] extern crate enum_primitive;
+
 #[cfg(test)]
 extern crate quickcheck;
 


### PR DESCRIPTION
Welcoming comments.

I have added a dependency because in needed both `ContentFormat -> u16` and `u16 -> ContentFormat` conversions. In order to not duplicate the constant values in the source code I have put them inside the `enum` (à la C style) and using the macro to generate the conversion functions.

This addresses #13.