### PR TITLE
more convenient method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coap"
-version = "0.5.3"
+version = "0.6.0"
 description = "A CoAP library"
 readme = "README.md"
 documentation = "http://covertness.github.io/coap-rs/coap/index.html"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ First add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-coap = "0.5"
+coap = "0.6"
 ```
 
 Then, add this to your crate root:
@@ -33,13 +33,17 @@ extern crate coap;
 extern crate coap;
 
 use std::io;
-use coap::{CoAPServer, CoAPResponse, CoAPRequest};
+use coap::{CoAPServer, CoAPResponse, CoAPRequest, Method};
 
-fn request_handler(req: CoAPRequest) -> Option<CoAPResponse> {
-    println!("Receive request: {:?}", req);
+fn request_handler(request: CoAPRequest) -> Option<CoAPResponse> {
+    match request.get_method() {
+		&Method::Get => println!("request by get {}", request.get_path()),
+		&Method::Post => println!("request by post {}", String::from_utf8(request.message.payload).unwrap()),
+		_ => println!("request by other method"),
+	};
 
     // Return the auto-generated response
-    req.response
+    request.response
 }
 
 fn main() {
@@ -66,7 +70,7 @@ fn main() {
     let url = "coap://127.0.0.1:5683/Rust";
     println!("Client request: {}", url);
 
-    let response: CoAPResponse = CoAPClient::request(url).unwrap();
+    let response = CoAPClient::get(url).unwrap();
     println!("Server reply: {}", String::from_utf8(response.message.payload).unwrap());
 }
 ```

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,7 +1,7 @@
 extern crate coap;
 
 use std::io::ErrorKind;
-use coap::{CoAPClient, CoAPRequest, IsMessage, MessageType, CoAPOption};
+use coap::{CoAPClient, CoAPRequest, IsMessage, Method};
 
 fn main() {
     println!("Request by GET:");
@@ -13,21 +13,10 @@ fn main() {
 
 
 fn example_get() {
-    let addr = "127.0.0.1:5683";
-    let endpoint = "test";
+    let url = "coap://127.0.0.1:5683/hello/get";
+    println!("Client request: {}", url);
 
-    let client = CoAPClient::new(addr).unwrap();
-    let mut request = CoAPRequest::new();
-    request.set_version(1);
-    request.set_type(MessageType::Confirmable);
-    request.set_code("0.01");
-    request.set_message_id(1);
-    request.set_token(vec![0x51, 0x55, 0x77, 0xE8]);
-    request.add_option(CoAPOption::UriPath, endpoint.to_string().into_bytes());
-    client.send(&request).unwrap();
-    println!("Client request: coap://{}/{}", addr, endpoint);
-
-    match client.receive() {
+    match CoAPClient::get(url) {
         Ok(response) => {
             println!("Server reply: {}",
                      String::from_utf8(response.message.payload).unwrap());
@@ -44,20 +33,16 @@ fn example_get() {
 
 fn example_post() {
     let addr = "127.0.0.1:5683";
-    let endpoint = "test";
+    let path = "/hello/post";
 
-    let client = CoAPClient::new(addr).unwrap();
     let mut request = CoAPRequest::new();
-    request.set_version(1);
-    request.set_type(MessageType::Confirmable);
-    request.set_code("0.02");
-    request.set_message_id(1);
-    request.set_token(vec![0x51, 0x55, 0x77, 0xE8]);
-    request.add_option(CoAPOption::UriPath, endpoint.to_string().into_bytes());
+    request.set_method(Method::Post);
+    request.set_path(path);
     request.set_payload(b"data".to_vec());
 
+    let client = CoAPClient::new(addr).unwrap();
     client.send(&request).unwrap();
-    println!("Client request: coap://{}/{}", addr, endpoint);
+    println!("Client request: coap://{}/{}", addr, path);
 
     match client.receive() {
         Ok(response) => {

--- a/examples/client_and_server.rs
+++ b/examples/client_and_server.rs
@@ -1,14 +1,14 @@
 extern crate coap;
 
-use coap::{CoAPServer, CoAPClient, CoAPRequest, CoAPResponse, CoAPOption};
+use coap::{CoAPServer, CoAPClient, CoAPRequest, CoAPResponse};
 use coap::IsMessage;
 
 fn request_handler(request: CoAPRequest) -> Option<CoAPResponse> {
-    let uri_path = request.get_option(CoAPOption::UriPath).unwrap();
+    let uri_path = request.get_path().to_string();
 
     return match request.response {
         Some(mut response) => {
-            response.set_payload(uri_path.front().unwrap().clone());
+            response.set_payload(uri_path.as_bytes().to_vec());
             Some(response)
         }
         _ => None,

--- a/examples/client_and_server.rs
+++ b/examples/client_and_server.rs
@@ -22,7 +22,7 @@ fn main() {
     let url = "coap://127.0.0.1:5683/Rust";
     println!("Client request: {}", url);
 
-    let response: CoAPResponse = CoAPClient::request(url).unwrap();
+    let response = CoAPClient::get(url).unwrap();
     println!("Server reply: {}",
              String::from_utf8(response.message.payload).unwrap());
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,21 +1,19 @@
 extern crate coap;
 
 use std::io;
-use coap::{CoAPServer, CoAPResponse, CoAPRequest, IsMessage};
+use coap::{CoAPServer, CoAPResponse, CoAPRequest, IsMessage, Method};
 
 fn request_handler(request: CoAPRequest) -> Option<CoAPResponse> {
-	let request_code = request.get_code();
-
-	match request_code.as_ref() {
-		"0.01" => {
-			println!("request by get");
+	match request.get_method() {
+		&Method::Get => {
+			println!("request by get {}", request.get_path());
 		},
-		"0.02" => {
-			println!("request by post");
+		&Method::Post => {
+			println!("request by post {}", request.get_path());
 			println!("request body: {}", String::from_utf8(request.message.payload).unwrap());
 		},
 		_ => {
-			println!("request by other method {}", request_code);
+			println!("request by other method");
 		}
 	};
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -5,16 +5,9 @@ use coap::{CoAPServer, CoAPResponse, CoAPRequest, IsMessage, Method};
 
 fn request_handler(request: CoAPRequest) -> Option<CoAPResponse> {
 	match request.get_method() {
-		&Method::Get => {
-			println!("request by get {}", request.get_path());
-		},
-		&Method::Post => {
-			println!("request by post {}", request.get_path());
-			println!("request body: {}", String::from_utf8(request.message.payload).unwrap());
-		},
-		_ => {
-			println!("request by other method");
-		}
+		&Method::Get => println!("request by get {}", request.get_path()),
+		&Method::Post => println!("request by post {}", String::from_utf8(request.message.payload).unwrap()),
+		_ => println!("request by other method"),
 	};
 
 	return match request.response {

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 use url::{UrlParser, SchemeType};
 use num;
 use rand::{thread_rng, random, Rng};
-use message::packet::{Packet, CoAPOption};
+use message::packet::Packet;
 use message::header::MessageType;
 use message::response::CoAPResponse;
-use message::request::CoAPRequest;
+use message::request::{CoAPRequest, Method};
 use message::IsMessage;
 
 const DEFAULT_RECEIVE_TIMEOUT: u64 = 5;  // 5s
@@ -63,7 +63,7 @@ impl CoAPClient {
                 let mut packet = CoAPRequest::new();
                 packet.set_version(1);
                 packet.set_type(MessageType::Confirmable);
-                packet.set_code("0.01");
+                packet.set_method(Method::Get);
 
                 let message_id = thread_rng().gen_range(0, num::pow(2u32, 16)) as u16;
                 packet.set_message_id(message_id);
@@ -80,10 +80,8 @@ impl CoAPClient {
                 };
                 let port = url_params.port_or_default().unwrap();
 
-                if let Some(path) = url_params.path() {
-                    for p in path.iter() {
-                        packet.add_option(CoAPOption::UriPath, p.clone().into_bytes().to_vec());
-                    }
+                if let Some(path) = url_params.serialize_path() {
+                    packet.set_path(path.as_str());
                 };
 
                 let client = try!(Self::new((domain, port)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! coap = "0.5"
+//! coap = "0.6"
 //! ```
 //!
 //! Then, add this to your crate root:
@@ -27,13 +27,17 @@
 //! extern crate coap;
 
 //! use std::io;
-//! use coap::{CoAPServer, CoAPClient, CoAPRequest, CoAPResponse};
+//! use coap::{CoAPServer, CoAPClient, CoAPRequest, CoAPResponse, Method};
 
 //! fn request_handler(request: CoAPRequest) -> Option<CoAPResponse> {
-//! 	println!("Receive request: {:?}", request);
-//!     
+//!     match request.get_method() {
+//! 		&Method::Get => println!("request by get {}", request.get_path()),
+//! 		&Method::Post => println!("request by post {}", String::from_utf8(request.message.payload).unwrap()),
+//! 		_ => println!("request by other method"),
+//! 	};
+//! 
 //!     // Return the auto-generated response
-//!     request.response
+//!    request.response
 //! }
 
 //! fn main() {
@@ -55,14 +59,13 @@
 //! ```no_run
 //! extern crate coap;
 //!
-//! use coap::message::response::CoAPResponse;
-//! use coap::CoAPClient;
+//! use coap::{CoAPClient, CoAPResponse};
 //!
 //! fn main() {
 //! 	let url = "coap://127.0.0.1:5683/Rust";
 //! 	println!("Client request: {}", url);
 //!
-//! 	let response: CoAPResponse = CoAPClient::request(url).unwrap();
+//! 	let response = CoAPClient::get(url).unwrap();
 //! 	println!("Server reply: {}", String::from_utf8(response.message.payload).unwrap());
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub use message::header::MessageType;
 pub use message::IsMessage;
 pub use message::packet::CoAPOption;
 pub use message::request::CoAPRequest;
+pub use message::request::Method;
 pub use message::response::CoAPResponse;
 pub use server::CoAPServer;
 

--- a/src/message/header.rs
+++ b/src/message/header.rs
@@ -1,8 +1,18 @@
-#[derive(Default, Debug, RustcEncodable, RustcDecodable)]
+#[derive(Debug, RustcEncodable, RustcDecodable)]
 pub struct HeaderRaw {
     ver_type_tkl: u8,
     code: u8,
     message_id: u16,
+}
+
+impl Default for HeaderRaw {
+    fn default() -> HeaderRaw {
+        HeaderRaw {
+            ver_type_tkl: 0x40, // version: 1, type: Confirmable, TKL: 0
+            code: 0x01,         // GET
+            message_id: 0,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/message/header.rs
+++ b/src/message/header.rs
@@ -15,21 +15,22 @@ pub struct Header {
 #[derive(Debug, PartialEq)]
 pub enum MessageClass {
     Empty,
-    RequestType(Requests),
-    ResponseType(Responses),
+    Request(RequestType),
+    Response(ResponseType),
     Reserved,
 }
 
 #[derive(Debug, PartialEq)]
-pub enum Requests {
+pub enum RequestType {
     Get,
     Post,
     Put,
     Delete,
+    UnKnown,
 }
 
 #[derive(Debug, PartialEq)]
-pub enum Responses {
+pub enum ResponseType {
     // 200 Codes
     Created,
     Deleted,
@@ -169,34 +170,34 @@ pub fn class_to_code(class: &MessageClass) -> u8 {
     return match *class {
         MessageClass::Empty => 0x00,
 
-        MessageClass::RequestType(Requests::Get) => 0x01,
-        MessageClass::RequestType(Requests::Post) => 0x02,
-        MessageClass::RequestType(Requests::Put) => 0x03,
-        MessageClass::RequestType(Requests::Delete) => 0x04,
+        MessageClass::Request(RequestType::Get) => 0x01,
+        MessageClass::Request(RequestType::Post) => 0x02,
+        MessageClass::Request(RequestType::Put) => 0x03,
+        MessageClass::Request(RequestType::Delete) => 0x04,
 
-        MessageClass::ResponseType(Responses::Created) => 0x41,
-        MessageClass::ResponseType(Responses::Deleted) => 0x42,
-        MessageClass::ResponseType(Responses::Valid) => 0x43,
-        MessageClass::ResponseType(Responses::Changed) => 0x44,
-        MessageClass::ResponseType(Responses::Content) => 0x45,
+        MessageClass::Response(ResponseType::Created) => 0x41,
+        MessageClass::Response(ResponseType::Deleted) => 0x42,
+        MessageClass::Response(ResponseType::Valid) => 0x43,
+        MessageClass::Response(ResponseType::Changed) => 0x44,
+        MessageClass::Response(ResponseType::Content) => 0x45,
 
-        MessageClass::ResponseType(Responses::BadRequest) => 0x80,
-        MessageClass::ResponseType(Responses::Unauthorized) => 0x81,
-        MessageClass::ResponseType(Responses::BadOption) => 0x82,
-        MessageClass::ResponseType(Responses::Forbidden) => 0x83,
-        MessageClass::ResponseType(Responses::NotFound) => 0x84,
-        MessageClass::ResponseType(Responses::MethodNotAllowed) => 0x85,
-        MessageClass::ResponseType(Responses::NotAcceptable) => 0x86,
-        MessageClass::ResponseType(Responses::PreconditionFailed) => 0x8C,
-        MessageClass::ResponseType(Responses::RequestEntityTooLarge) => 0x8D,
-        MessageClass::ResponseType(Responses::UnsupportedContentFormat) => 0x8F,
+        MessageClass::Response(ResponseType::BadRequest) => 0x80,
+        MessageClass::Response(ResponseType::Unauthorized) => 0x81,
+        MessageClass::Response(ResponseType::BadOption) => 0x82,
+        MessageClass::Response(ResponseType::Forbidden) => 0x83,
+        MessageClass::Response(ResponseType::NotFound) => 0x84,
+        MessageClass::Response(ResponseType::MethodNotAllowed) => 0x85,
+        MessageClass::Response(ResponseType::NotAcceptable) => 0x86,
+        MessageClass::Response(ResponseType::PreconditionFailed) => 0x8C,
+        MessageClass::Response(ResponseType::RequestEntityTooLarge) => 0x8D,
+        MessageClass::Response(ResponseType::UnsupportedContentFormat) => 0x8F,
 
-        MessageClass::ResponseType(Responses::InternalServerError) => 0x90,
-        MessageClass::ResponseType(Responses::NotImplemented) => 0x91,
-        MessageClass::ResponseType(Responses::BadGateway) => 0x92,
-        MessageClass::ResponseType(Responses::ServiceUnavailable) => 0x93,
-        MessageClass::ResponseType(Responses::GatewayTimeout) => 0x94,
-        MessageClass::ResponseType(Responses::ProxyingNotSupported) => 0x95,
+        MessageClass::Response(ResponseType::InternalServerError) => 0x90,
+        MessageClass::Response(ResponseType::NotImplemented) => 0x91,
+        MessageClass::Response(ResponseType::BadGateway) => 0x92,
+        MessageClass::Response(ResponseType::ServiceUnavailable) => 0x93,
+        MessageClass::Response(ResponseType::GatewayTimeout) => 0x94,
+        MessageClass::Response(ResponseType::ProxyingNotSupported) => 0x95,
 
         _ => 0xFF,
     } as u8;
@@ -206,34 +207,34 @@ pub fn code_to_class(code: &u8) -> MessageClass {
     match *code {
         0x00 => MessageClass::Empty,
 
-        0x01 => MessageClass::RequestType(Requests::Get),
-        0x02 => MessageClass::RequestType(Requests::Post),
-        0x03 => MessageClass::RequestType(Requests::Put),
-        0x04 => MessageClass::RequestType(Requests::Delete),
+        0x01 => MessageClass::Request(RequestType::Get),
+        0x02 => MessageClass::Request(RequestType::Post),
+        0x03 => MessageClass::Request(RequestType::Put),
+        0x04 => MessageClass::Request(RequestType::Delete),
 
-        0x41 => MessageClass::ResponseType(Responses::Created),
-        0x42 => MessageClass::ResponseType(Responses::Deleted),
-        0x43 => MessageClass::ResponseType(Responses::Valid),
-        0x44 => MessageClass::ResponseType(Responses::Changed),
-        0x45 => MessageClass::ResponseType(Responses::Content),
+        0x41 => MessageClass::Response(ResponseType::Created),
+        0x42 => MessageClass::Response(ResponseType::Deleted),
+        0x43 => MessageClass::Response(ResponseType::Valid),
+        0x44 => MessageClass::Response(ResponseType::Changed),
+        0x45 => MessageClass::Response(ResponseType::Content),
 
-        0x80 => MessageClass::ResponseType(Responses::BadRequest),
-        0x81 => MessageClass::ResponseType(Responses::Unauthorized),
-        0x82 => MessageClass::ResponseType(Responses::BadOption),
-        0x83 => MessageClass::ResponseType(Responses::Forbidden),
-        0x84 => MessageClass::ResponseType(Responses::NotFound),
-        0x85 => MessageClass::ResponseType(Responses::MethodNotAllowed),
-        0x86 => MessageClass::ResponseType(Responses::NotAcceptable),
-        0x8C => MessageClass::ResponseType(Responses::PreconditionFailed),
-        0x8D => MessageClass::ResponseType(Responses::RequestEntityTooLarge),
-        0x8F => MessageClass::ResponseType(Responses::UnsupportedContentFormat),
+        0x80 => MessageClass::Response(ResponseType::BadRequest),
+        0x81 => MessageClass::Response(ResponseType::Unauthorized),
+        0x82 => MessageClass::Response(ResponseType::BadOption),
+        0x83 => MessageClass::Response(ResponseType::Forbidden),
+        0x84 => MessageClass::Response(ResponseType::NotFound),
+        0x85 => MessageClass::Response(ResponseType::MethodNotAllowed),
+        0x86 => MessageClass::Response(ResponseType::NotAcceptable),
+        0x8C => MessageClass::Response(ResponseType::PreconditionFailed),
+        0x8D => MessageClass::Response(ResponseType::RequestEntityTooLarge),
+        0x8F => MessageClass::Response(ResponseType::UnsupportedContentFormat),
 
-        0x90 => MessageClass::ResponseType(Responses::InternalServerError),
-        0x91 => MessageClass::ResponseType(Responses::NotImplemented),
-        0x92 => MessageClass::ResponseType(Responses::BadGateway),
-        0x93 => MessageClass::ResponseType(Responses::ServiceUnavailable),
-        0x94 => MessageClass::ResponseType(Responses::GatewayTimeout),
-        0x95 => MessageClass::ResponseType(Responses::ProxyingNotSupported),
+        0x90 => MessageClass::Response(ResponseType::InternalServerError),
+        0x91 => MessageClass::Response(ResponseType::NotImplemented),
+        0x92 => MessageClass::Response(ResponseType::BadGateway),
+        0x93 => MessageClass::Response(ResponseType::ServiceUnavailable),
+        0x94 => MessageClass::Response(ResponseType::GatewayTimeout),
+        0x95 => MessageClass::Response(ResponseType::ProxyingNotSupported),
 
         _ => MessageClass::Reserved,
     }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -29,7 +29,7 @@ pub trait IsMessage {
     fn add_option(&mut self, tp: packet::CoAPOption, value: Vec<u8>) {
         self.get_mut_message().add_option(tp, value);
     }
-    fn get_option(&self, tp: packet::CoAPOption) -> Option<LinkedList<Vec<u8>>> {
+    fn get_option(&self, tp: packet::CoAPOption) -> Option<&LinkedList<Vec<u8>>> {
         return self.get_message().get_option(tp);
     }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -32,6 +32,9 @@ pub trait IsMessage {
     fn get_option(&self, tp: packet::CoAPOption) -> Option<&LinkedList<Vec<u8>>> {
         return self.get_message().get_option(tp);
     }
+    fn clear_option(&mut self, tp: packet::CoAPOption) {
+        self.get_mut_message().clear_option(tp);
+    }
 
     fn get_message_id(&self) -> u16 {
         return self.get_message().header.get_message_id();

--- a/src/message/packet.rs
+++ b/src/message/packet.rs
@@ -120,12 +120,9 @@ impl Packet {
         self.options.insert(num, list);
     }
 
-    pub fn get_option(&self, tp: CoAPOption) -> Option<LinkedList<Vec<u8>>> {
+    pub fn get_option(&self, tp: CoAPOption) -> Option<&LinkedList<Vec<u8>>> {
         let num = Self::get_option_number(tp);
-        match self.options.get(&num) {
-            Some(options) => Some(options.clone()),
-            None => None,
-        }
+        self.options.get(&num)
     }
 
     pub fn get_content_format(&self) -> Option<ContentFormat> {
@@ -410,7 +407,7 @@ mod test {
         assert_eq!(packet.header.get_type(), header::MessageType::Confirmable);
         assert_eq!(packet.header.get_token_length(), 4);
         assert_eq!(packet.header.code,
-                   header::MessageClass::RequestType(header::Requests::Get));
+                   header::MessageClass::Request(header::RequestType::Get));
         assert_eq!(packet.header.get_message_id(), 33950);
         assert_eq!(*packet.get_token(), vec![0x51, 0x55, 0x77, 0xE8]);
         assert_eq!(packet.options.len(), 2);
@@ -421,14 +418,14 @@ mod test {
         let mut expected_uri_path = LinkedList::new();
         expected_uri_path.push_back("Hi".as_bytes().to_vec());
         expected_uri_path.push_back("Test".as_bytes().to_vec());
-        assert_eq!(uri_path, expected_uri_path);
+        assert_eq!(*uri_path, expected_uri_path);
 
         let uri_query = packet.get_option(CoAPOption::UriQuery);
         assert!(uri_query.is_some());
         let uri_query = uri_query.unwrap();
         let mut expected_uri_query = LinkedList::new();
         expected_uri_query.push_back("a=1".as_bytes().to_vec());
-        assert_eq!(uri_query, expected_uri_query);
+        assert_eq!(*uri_query, expected_uri_query);
     }
 
     #[test]
@@ -443,7 +440,7 @@ mod test {
                    header::MessageType::Acknowledgement);
         assert_eq!(packet.header.get_token_length(), 4);
         assert_eq!(packet.header.code,
-                   header::MessageClass::ResponseType(header::Responses::Content));
+                   header::MessageClass::Response(header::ResponseType::Content));
         assert_eq!(packet.header.get_message_id(), 5117);
         assert_eq!(*packet.get_token(), vec![0xD0, 0xE2, 0x4D, 0xAC]);
         assert_eq!(packet.payload, "Hello".as_bytes().to_vec());
@@ -454,7 +451,7 @@ mod test {
         let mut packet = Packet::new();
         packet.header.set_version(1);
         packet.header.set_type(header::MessageType::Confirmable);
-        packet.header.code = header::MessageClass::RequestType(header::Requests::Get);
+        packet.header.code = header::MessageClass::Request(header::RequestType::Get);
         packet.header.set_message_id(33950);
         packet.set_token(vec![0x51, 0x55, 0x77, 0xE8]);
         packet.add_option(CoAPOption::UriPath, b"Hi".to_vec());
@@ -470,7 +467,7 @@ mod test {
         let mut packet = Packet::new();
         packet.header.set_version(1);
         packet.header.set_type(header::MessageType::Acknowledgement);
-        packet.header.code = header::MessageClass::ResponseType(header::Responses::Content);
+        packet.header.code = header::MessageClass::Response(header::ResponseType::Content);
         packet.header.set_message_id(5117);
         packet.set_token(vec![0xD0, 0xE2, 0x4D, 0xAC]);
         packet.payload = "Hello".as_bytes().to_vec();

--- a/src/message/packet.rs
+++ b/src/message/packet.rs
@@ -125,6 +125,13 @@ impl Packet {
         self.options.get(&num)
     }
 
+    pub fn clear_option(&mut self, tp: CoAPOption) {
+        let num = Self::get_option_number(tp);
+        if let Some(list) = self.options.get_mut(&num) {
+            list.clear()
+        }
+    }
+
     pub fn get_content_format(&self) -> Option<ContentFormat> {
         if let Some(list) = self.get_option(CoAPOption::ContentFormat) {
             if let Some(vector) = list.front() {

--- a/src/message/request.rs
+++ b/src/message/request.rs
@@ -1,10 +1,11 @@
 use message::IsMessage;
 use message::response::CoAPResponse;
-use message::packet::{Packet, CoAPOption};
+use message::packet::{CoAPOption, Packet};
 use message::header::{Header, MessageClass};
-pub use message::header::RequestType as Method;
 use std::net::SocketAddr;
 use std::str;
+
+pub use message::header::RequestType as Method;
 
 #[derive(Debug)]
 pub struct CoAPRequest {
@@ -30,6 +31,10 @@ impl CoAPRequest {
         }
     }
 
+    pub fn set_method(&mut self, method: Method) {
+        self.message.header.code = MessageClass::Request(method);
+    }
+
     pub fn get_method(&self) -> &Method {
         match self.message.header.code {
             MessageClass::Request(Method::Get) => &Method::Get,
@@ -40,20 +45,31 @@ impl CoAPRequest {
         }
     }
 
-    pub fn get_path(&self) -> &str {
+    pub fn set_path(&mut self, path: &str) {
+        self.clear_option(CoAPOption::UriPath);
+
+        let segs = path.split("/");
+        for s in segs {
+            if s.len() == 0 {
+                continue;
+            }
+
+            self.add_option(CoAPOption::UriPath, s.as_bytes().to_vec());
+        }
+    }
+
+    pub fn get_path(&self) -> String {
         match self.get_option(CoAPOption::UriPath) {
             Some(options) => {
-                match options.front() {
-                    Some(uri) => {
-                        match str::from_utf8(uri) {
-                            Ok(path) => path.clone(),
-                            _ => "",
-                        }
-                    },
-                    _ => ""
+                let mut vec = Vec::new();
+                for option in options.iter() {
+                    if let Ok(seg) = str::from_utf8(option) {
+                        vec.push(seg);
+                    }
                 }
-            },
-            _ => ""
+                vec.join("/")
+            }
+            _ => "".to_string(),
         }
     }
 }
@@ -76,7 +92,7 @@ impl IsMessage for CoAPRequest {
 #[cfg(test)]
 mod test {
     use super::*;
-    use message::packet::{Packet, CoAPOption};
+    use message::packet::{CoAPOption, Packet};
     use message::header::MessageType;
     use message::IsMessage;
     use std::net::SocketAddr;
@@ -106,11 +122,71 @@ mod test {
         packet.header.set_code("0.04");
         request1.set_code("0.04");
 
-        let request2 = CoAPRequest::from_packet(packet,
-                                                &SocketAddr::from_str("127.0.0.1:1234").unwrap());
+        let request2 =
+            CoAPRequest::from_packet(packet, &SocketAddr::from_str("127.0.0.1:1234").unwrap());
 
-        assert_eq!(request1.message.to_bytes().unwrap(),
-                   request2.message.to_bytes().unwrap());
+        assert_eq!(
+            request1.message.to_bytes().unwrap(),
+            request2.message.to_bytes().unwrap()
+        );
+    }
 
+    #[test]
+    fn test_method() {
+        let mut request = CoAPRequest::new();
+
+        request.set_code("0.01");
+        assert_eq!(&Method::Get, request.get_method());
+
+        request.set_code("0.02");
+        assert_eq!(&Method::Post, request.get_method());
+
+        request.set_code("0.03");
+        assert_eq!(&Method::Put, request.get_method());
+
+        request.set_code("0.04");
+        assert_eq!(&Method::Delete, request.get_method());
+
+        request.set_method(Method::Get);
+        assert_eq!("0.01", request.get_code());
+
+        request.set_method(Method::Post);
+        assert_eq!("0.02", request.get_code());
+
+        request.set_method(Method::Put);
+        assert_eq!("0.03", request.get_code());
+
+        request.set_method(Method::Delete);
+        assert_eq!("0.04", request.get_code());
+    }
+
+    #[test]
+    fn test_path() {
+        let mut request = CoAPRequest::new();
+
+        let path = "test-interface";
+        request.add_option(CoAPOption::UriPath, path.as_bytes().to_vec());
+        assert_eq!(path, request.get_path());
+
+        let path2 = "test-interface2";
+        request.set_path(path2);
+        assert_eq!(
+            path2.as_bytes().to_vec(),
+            *request
+                .get_option(CoAPOption::UriPath)
+                .unwrap()
+                .front()
+                .unwrap()
+        );
+
+        request.set_path("/test-interface2");
+        assert_eq!(
+            path2.as_bytes().to_vec(),
+            *request
+                .get_option(CoAPOption::UriPath)
+                .unwrap()
+                .front()
+                .unwrap()
+        );
     }
 }

--- a/src/message/request.rs
+++ b/src/message/request.rs
@@ -1,8 +1,10 @@
 use message::IsMessage;
 use message::response::CoAPResponse;
-use message::packet::Packet;
-use message::header::Header;
+use message::packet::{Packet, CoAPOption};
+use message::header::{Header, MessageClass};
+pub use message::header::RequestType as Method;
 use std::net::SocketAddr;
+use std::str;
 
 #[derive(Debug)]
 pub struct CoAPRequest {
@@ -25,6 +27,33 @@ impl CoAPRequest {
             response: CoAPResponse::new(&packet),
             message: packet,
             source: Some(source.clone()),
+        }
+    }
+
+    pub fn get_method(&self) -> &Method {
+        match self.message.header.code {
+            MessageClass::Request(Method::Get) => &Method::Get,
+            MessageClass::Request(Method::Post) => &Method::Post,
+            MessageClass::Request(Method::Put) => &Method::Put,
+            MessageClass::Request(Method::Delete) => &Method::Delete,
+            _ => &Method::UnKnown,
+        }
+    }
+
+    pub fn get_path(&self) -> &str {
+        match self.get_option(CoAPOption::UriPath) {
+            Some(options) => {
+                match options.front() {
+                    Some(uri) => {
+                        match str::from_utf8(uri) {
+                            Ok(path) => path.clone(),
+                            _ => "",
+                        }
+                    },
+                    _ => ""
+                }
+            },
+            _ => ""
         }
     }
 }

--- a/src/message/response.rs
+++ b/src/message/response.rs
@@ -1,6 +1,6 @@
 use message::IsMessage;
 use message::packet::Packet;
-use message::header::{Header, MessageType, MessageClass, Responses};
+use message::header::{Header, MessageType, MessageClass, ResponseType};
 
 #[derive(Debug)]
 pub struct CoAPResponse {
@@ -18,7 +18,7 @@ impl CoAPResponse {
             _ => return None,
         };
         packet.header.set_type(response_type);
-        packet.header.code = MessageClass::ResponseType(Responses::Content);
+        packet.header.code = MessageClass::Response(ResponseType::Content);
         packet.header.set_message_id(request.header.get_message_id());
         packet.set_token(request.get_token().clone());
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -324,7 +324,7 @@ mod test {
     use super::*;
 
     fn request_handler(req: CoAPRequest) -> Option<CoAPResponse> {
-        let uri_path_list = req.get_option(CoAPOption::UriPath).unwrap();
+        let uri_path_list = req.get_option(CoAPOption::UriPath).unwrap().clone();
         assert!(uri_path_list.len() == 1);
 
         match req.response {


### PR DESCRIPTION
Make the library interface more convenient, like some `http` libraries.
1. replace `request` with `get`.
2. set `01000000`(version: 1, type: confirmable, tkl: 0) as default header.
3. add `method` and `path` attributes for `CoAPRequest`.

@jamesmunns do you have time to review them ?