### PR TITLE
socket_addr: Return the local address that the server is listening on

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coap"
-version = "0.7.3"
+version = "0.7.4"
 description = "A CoAP library"
 readme = "README.md"
 documentation = "http://covertness.github.io/coap-rs/master/coap/index.html"


### PR DESCRIPTION
The [current constructor](https://github.com/Covertness/coap-rs/blob/master/src/server.rs#L268) takes a SocketAddrs, which works in 99% of cases, but I wanted to start up a server for unit testing on a random open OS assigned port (ephemeral port). This is easy to do, just pass in a SocketAddrs with port 0, the issue is there is no way to get back the port that as assigned. So, I added a the `socket_addr()` function to return the assigned address info.

NOTE: I bumped the version number since this is an API change, but please let me know if this is not necessary.