### PR TITLE
Upgraded bincode, and set edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,18 @@ repository = "https://github.com/covertness/coap-rs"
 license = "MIT"
 authors = ["Yang Zhang <wuyingfengsui@gmail.com>"]
 keywords = ["CoAP"]
+edition = "2018"
 
 [dependencies]
-bincode = "0.3.0"
-rustc-serialize = "0.3"
+bincode = "1.1.1"
+serde = { version= "1.0.88", features= [ "derive" ] }
 mio = "0.5"
 url = "1.7.1"
-num = "0.1"
+num = "0.2.0"
+num-derive = "0.2.4"
+num-traits = "0.2.6"
 rand = "0.3"
-log = "0.3"
+log = "0.4.6"
 threadpool = "1.3"
 enum_primitive = "0.1.1"
 regex = "1.0.2"

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,11 +6,12 @@ use std::sync::mpsc;
 use url::Url;
 use num;
 use rand::{random, thread_rng, Rng};
-use message::packet::{Packet, ObserveOption};
-use message::header::MessageType;
-use message::response::{CoAPResponse, Status};
-use message::request::{CoAPRequest, Method};
-use message::IsMessage;
+use log::*;
+use super::message::packet::{Packet, ObserveOption};
+use super::message::header::MessageType;
+use super::message::response::{CoAPResponse, Status};
+use super::message::request::{CoAPRequest, Method};
+use super::message::IsMessage;
 use regex::Regex;
 
 const DEFAULT_RECEIVE_TIMEOUT: u64 = 1; // 1s
@@ -191,10 +192,10 @@ impl CoAPClient {
         packet.set_token(token.clone());
         packet.set_path(path.as_str());
 
-        let client = try!(Self::new((domain.as_str(), port)));
-        try!(client.send(&packet));
+        let client = r#try!(Self::new((domain.as_str(), port)));
+        r#try!(client.send(&packet));
 
-        try!(client.set_receive_timeout(timeout));
+        r#try!(client.set_receive_timeout(timeout));
         match client.receive() {
             Ok(receive_packet) => {
                 if receive_packet.get_message_id() == message_id
@@ -234,7 +235,7 @@ impl CoAPClient {
     fn send_with_socket(socket: &UdpSocket, peer_addr: &SocketAddr, message: &Packet) -> Result<()> {
         match message.to_bytes() {
             Ok(bytes) => {
-                let size = try!(socket.send_to(&bytes[..], peer_addr));
+                let size = r#try!(socket.send_to(&bytes[..], peer_addr));
                 if size == bytes.len() {
                     Ok(())
                 } else {
@@ -248,7 +249,7 @@ impl CoAPClient {
     fn receive_from_socket(socket: &UdpSocket) -> Result<Packet> {
         let mut buf = [0; 1500];
 
-        let (nread, _src) = try!(socket.recv_from(&mut buf));
+        let (nread, _src) = r#try!(socket.recv_from(&mut buf));
         match Packet::from_bytes(&buf[..nread]) {
             Ok(packet) => Ok(packet),
             Err(_) => Err(Error::new(ErrorKind::InvalidInput, "packet error")),
@@ -295,9 +296,9 @@ mod test {
     use super::*;
     use std::time::Duration;
     use std::io::ErrorKind;
-    use message::request::CoAPRequest;
-    use message::response::CoAPResponse;
-    use server::CoAPServer;
+    use super::super::message::request::CoAPRequest;
+    use super::super::message::response::CoAPResponse;
+    use super::super::server::CoAPServer;
 
     #[test]
     fn test_parse_coap_url_good_url() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,33 +72,22 @@
 //! }
 //! ```
 
-extern crate bincode;
-extern crate rustc_serialize;
-extern crate mio;
-extern crate url;
-extern crate num;
-extern crate rand;
-extern crate threadpool;
-extern crate regex;
-#[macro_use] extern crate enum_primitive;
-
 #[cfg(test)]
 extern crate quickcheck;
 
-#[macro_use]
-extern crate log;
-
-pub use client::CoAPClient;
-pub use message::header::MessageType;
-pub use message::IsMessage;
-pub use message::packet::CoAPOption;
-pub use message::request::CoAPRequest;
-pub use message::request::Method;
-pub use message::response::CoAPResponse;
-pub use message::response::Status;
-pub use server::CoAPServer;
-
+pub use self::client::CoAPClient;
+pub use self::message::header::MessageType;
+pub use self::message::IsMessage;
+pub use self::message::packet::CoAPOption;
+pub use self::message::request::CoAPRequest;
+pub use self::message::request::Method;
+pub use self::message::response::CoAPResponse;
+pub use self::message::response::Status;
+pub use self::server::CoAPServer;
 pub mod message;
 pub mod client;
 pub mod server;
 mod observer;
+
+
+

--- a/src/message/header.rs
+++ b/src/message/header.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, RustcEncodable, RustcDecodable)]
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct HeaderRaw {
     ver_type_tkl: u8,
     code: u8,
@@ -17,7 +19,7 @@ impl Default for HeaderRaw {
 
 #[derive(Clone, Debug)]
 pub struct Header {
-    ver_type_tkl: u8,
+    ver_type_tkl: u8,   
     pub code: MessageClass,
     message_id: u16,
 }
@@ -270,7 +272,7 @@ pub fn class_to_str(class: &MessageClass) -> String {
 
 #[cfg(test)]
 mod test {
-    use message::header::*;
+    use super::*;
 
     #[test]
     fn test_header_codes() {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -3,9 +3,8 @@ pub mod request;
 pub mod response;
 pub mod packet;
 
-use message::packet::Packet;
-use message::header::Header;
-
+use self::packet::Packet;
+use self::header::Header;
 use std::collections::LinkedList;
 
 pub trait IsMessage {

--- a/src/message/request.rs
+++ b/src/message/request.rs
@@ -1,11 +1,11 @@
-use message::IsMessage;
-use message::response::CoAPResponse;
-use message::packet::{CoAPOption, Packet};
-use message::header::{Header, MessageClass};
+use super::IsMessage;
+use super::response::CoAPResponse;
+use super::packet::{CoAPOption, Packet};
+use super::header::{Header, MessageClass};
 use std::net::SocketAddr;
 use std::str;
 
-pub use message::header::RequestType as Method;
+pub use super::header::RequestType as Method;
 
 #[derive(Clone, Debug)]
 pub struct CoAPRequest {
@@ -92,9 +92,9 @@ impl IsMessage for CoAPRequest {
 #[cfg(test)]
 mod test {
     use super::*;
-    use message::packet::{CoAPOption, Packet};
-    use message::header::MessageType;
-    use message::IsMessage;
+    use super::super::packet::{CoAPOption, Packet};
+    use super::super::header::MessageType;
+    use super::IsMessage;
     use std::net::SocketAddr;
     use std::str::FromStr;
 

--- a/src/message/response.rs
+++ b/src/message/response.rs
@@ -1,8 +1,8 @@
-use message::IsMessage;
-use message::packet::Packet;
-use message::header::{Header, MessageClass, MessageType};
+use super::IsMessage;
+use super::packet::Packet;
+use super::header::{Header, MessageClass, MessageType};
 
-pub use message::header::ResponseType as Status;
+pub use super::header::ResponseType as Status;
 
 #[derive(Clone, Debug)]
 pub struct CoAPResponse {
@@ -83,8 +83,8 @@ impl IsMessage for CoAPResponse {
 #[cfg(test)]
 mod test {
     use super::*;
-    use message::packet::Packet;
-    use message::header::MessageType;
+    use super::super::packet::Packet;
+    use super::super::header::MessageType;
 
     #[test]
     fn test_new_response_valid() {

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -1,13 +1,15 @@
 use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry;
 use std::net::SocketAddr;
-use message::request::{CoAPRequest, Method};
-use message::response::Status;
-use message::packet::{ObserveOption, Packet};
-use message::IsMessage;
-use message::header::{MessageClass, MessageType, ResponseType};
-use server::{QueuedMessage, TxQueue};
+use log::{debug, warn};
 use bincode;
+
+use super::message::request::{CoAPRequest, Method};
+use super::message::response::Status;
+use super::message::packet::{ObserveOption, Packet};
+use super::message::IsMessage;
+use super::message::header::{MessageClass, MessageType, ResponseType};
+use super::server::{QueuedMessage, TxQueue};
 
 const DEFAULT_UNACKNOWLEDGE_MESSAGE_TRY_TIMES: usize = 10;
 
@@ -349,7 +351,7 @@ impl<N: Fn() + Send + 'static> Observer<N> {
             let resource = self.resources.get(&register_resource.resource).unwrap();
 
             let mut sequence_bin =
-                bincode::encode(&resource.sequence, bincode::SizeLimit::Infinite).unwrap();
+                bincode::config().big_endian().serialize(&resource.sequence).unwrap();
             let index = sequence_bin.iter().position(|&x| x > 0).unwrap();
             sequence_bin.drain(0..index);
 
@@ -395,12 +397,8 @@ mod test {
     use std::io::ErrorKind;
     use std::sync::mpsc;
     use std::time::Duration;
-    use server::CoAPServer;
-    use client::CoAPClient;
-    use message::IsMessage;
-    use message::packet::ObserveOption;
-    use message::request::{CoAPRequest, Method};
-    use message::response::CoAPResponse;
+    use super::*;
+    use super::super::*;
 
     fn request_handler(req: CoAPRequest) -> Option<CoAPResponse> {
         match req.get_method() {

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,12 +5,13 @@ use std::net::{ToSocketAddrs, SocketAddr};
 use std::sync::mpsc;
 use mio::{EventLoop, PollOpt, EventSet, Handler, Sender, Token};
 use mio::udp::UdpSocket;
-use message::packet::Packet;
-use message::request::{CoAPRequest};
-use message::IsMessage;
-use message::response::CoAPResponse;
+use log::{warn, debug, error, info};
+use super::message::packet::Packet;
+use super::message::request::{CoAPRequest};
+use super::message::IsMessage;
+use super::message::response::CoAPResponse;
 use threadpool::ThreadPool;
-use observer::Observer;
+use super::observer::Observer;
 
 const DEFAULT_WORKER_NUM: usize = 4;
 
@@ -57,7 +58,7 @@ enum ResponseError {
 }
 
 pub trait CoAPHandler: Sync + Send + Copy {
-    fn handle(&self, CoAPRequest) -> Option<CoAPResponse>;
+    fn handle(&self, request: CoAPRequest) -> Option<CoAPResponse>;
 }
 
 impl<F> CoAPHandler for F
@@ -399,12 +400,7 @@ impl Drop for CoAPServer {
 #[cfg(test)]
 mod test {
     use std::time::Duration;
-    use client::CoAPClient;
-    use message::header;
-    use message::IsMessage;
-    use message::packet::CoAPOption;
-    use message::request::{CoAPRequest, Method};
-    use message::response::CoAPResponse;
+    use super::super::*;
     use super::*;
 
     fn request_handler(req: CoAPRequest) -> Option<CoAPResponse> {
@@ -428,7 +424,7 @@ mod test {
         let client = CoAPClient::new("127.0.0.1:5683").unwrap();
         let mut request = CoAPRequest::new();
         request.set_version(1);
-        request.set_type(header::MessageType::Confirmable);
+        request.set_type(MessageType::Confirmable);
         request.set_code("0.01");
         request.set_message_id(1);
         request.set_token(vec![0x51, 0x55, 0x77, 0xE8]);
@@ -447,7 +443,7 @@ mod test {
         let client = CoAPClient::new("127.0.0.1:5685").unwrap();
         let mut packet = CoAPRequest::new();
         packet.set_version(1);
-        packet.set_type(header::MessageType::Confirmable);
+        packet.set_type(MessageType::Confirmable);
         packet.set_code("0.01");
         packet.set_message_id(1);
         packet.add_option(CoAPOption::UriPath, b"test-echo".to_vec());
@@ -524,7 +520,7 @@ mod test {
         let client = CoAPClient::new(client_addr).unwrap();
         let mut request = CoAPRequest::new();
         request.set_version(1);
-        request.set_type(header::MessageType::Confirmable);
+        request.set_type(MessageType::Confirmable);
         request.set_code("0.01");
         request.set_message_id(1);
         request.set_token(vec![0x51, 0x55, 0x77, 0xE8]);


### PR DESCRIPTION
Pre-block1 transfer I wanted to bring the code up to speed with edition 2018 of Rust. I also upgraded some dependencies along the road.

I plan to bring all dependencies up to current versions, but that might follow in later pull requests.
