### PR TITLE
Improvement: primitive cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ num-traits = "0.2.6"
 rand = "0.3"
 log = "0.4.6"
 threadpool = "1.7.1"
-enum_primitive = "0.1.1"
 regex = "1.1.0"
 
 [dev-dependencies]

--- a/src/message/packet.rs
+++ b/src/message/packet.rs
@@ -176,7 +176,7 @@ impl Packet {
 
     /// Decodes a byte slice and construct the equivalent Packet.
     pub fn from_bytes(buf: &[u8]) -> Result<Packet, ParseError> {
-        
+
         let header_result: bincode::Result<header::HeaderRaw> = bincode::config().big_endian().deserialize(buf);
         match header_result {
             Ok(raw_header) => {

--- a/src/message/packet.rs
+++ b/src/message/packet.rs
@@ -123,13 +123,10 @@ impl Packet {
 
     pub fn add_option(&mut self, tp: CoAPOption, value: Vec<u8>) {
         let num = Self::get_option_number(tp);
-        match self.options.get_mut(&num) {
-            Some(list) => {
-                list.push_back(value);
-                return;
-            }
-            None => (),
-        };
+        if let Some(list) = self.options.get_mut(&num) {
+            list.push_back(value);
+            return;
+        }
 
         let mut list = LinkedList::new();
         list.push_back(value);


### PR DESCRIPTION
Cleanup previous `enum_primitive` introduction.