### PR TITLE
Implement RFC 8516

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A fast and stable [Constrained Application Protocol(CoAP)](https://tools.ietf.or
 Features:
 - CoAP core protocol [RFC 7252](https://tools.ietf.org/rfc/rfc7252.txt)
 - CoAP Observe option [RFC 7641](https://tools.ietf.org/rfc/rfc7641.txt)
+- *Too Many Requests* Response Code [RFC 8516](https://tools.ietf.org/html/rfc8516)
 
 [Documentation](http://covertness.github.io/coap-rs/master/coap/index.html)
 

--- a/src/message/header.rs
+++ b/src/message/header.rs
@@ -63,6 +63,7 @@ pub enum ResponseType {
     RequestEntityTooLarge,
     UnsupportedContentFormat,
     RequestEntityIncomplete,
+    TooManyRequests,
 
     // 500 Codes
     InternalServerError,
@@ -209,6 +210,7 @@ pub fn class_to_code(class: &MessageClass) -> u8 {
         MessageClass::Response(ResponseType::RequestEntityTooLarge) => 0x8D,
         MessageClass::Response(ResponseType::UnsupportedContentFormat) => 0x8F,
         MessageClass::Response(ResponseType::RequestEntityIncomplete) => 0x88,
+        MessageClass::Response(ResponseType::TooManyRequests) => 0x9d,
 
         MessageClass::Response(ResponseType::InternalServerError) => 0x90,
         MessageClass::Response(ResponseType::NotImplemented) => 0x91,
@@ -248,6 +250,7 @@ pub fn code_to_class(code: &u8) -> MessageClass {
         0x8D => MessageClass::Response(ResponseType::RequestEntityTooLarge),
         0x8F => MessageClass::Response(ResponseType::UnsupportedContentFormat),
         0x88 => MessageClass::Response(ResponseType::RequestEntityIncomplete),
+        0x9d => MessageClass::Response(ResponseType::TooManyRequests),
 
         0x90 => MessageClass::Response(ResponseType::InternalServerError),
         0x91 => MessageClass::Response(ResponseType::NotImplemented),


### PR DESCRIPTION
RFC 8516 consists of adding a new response code "Too Many Requests" and
defining its meaning.