### PR TITLE
README: remove extern crate instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,11 @@ First add this to your `Cargo.toml`:
 coap = "0.8"
 ```
 
-Then, add this to your crate root:
-
-```rust
-extern crate coap;
-```
-
 ## Example
 
 ### Server:
 ```rust
 #![feature(async_closure)]
-
-extern crate coap;
 
 use coap::{Server, IsMessage, Method};
 use tokio::runtime::Runtime;
@@ -71,8 +63,6 @@ fn main() {
 
 ### Client:
 ```rust
-extern crate coap;
-
 use coap::{CoAPClient, CoAPResponse};
 
 fn main() {


### PR DESCRIPTION
> Beginning in the 2018 edition, use declarations can reference crates in the extern prelude, so it is considered unidiomatic to use extern crate.

from: https://doc.rust-lang.org/reference/items/extern-crates.html