### PR TITLE
Bump coap-lite to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tokio =  {version = "0.2", features = ["full"]}
 tokio-util = {version = "0.2", features = ["codec", "udp"]}
 futures = "0.3"
 bytes = "0.5"
-coap-lite = "0.3.2"
+coap-lite = "0.3.4"
 
 [dev-dependencies]
 quickcheck = "0.8.2"


### PR DESCRIPTION
We added support to CoRE Link Format ([RFC6690](https://tools.ietf.org/html/rfc6690#:~:text=well%2Dknown%2Fcore%22%20is,other%20suitable%20web%20transfer%20protocol.)) in https://github.com/martindisch/coap-lite/pull/4 