### PR TITLE
Update coap-lite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["CoAP"]
 edition = "2018"
 
 [dependencies]
-serde = { version= "1.0.88", features= [ "derive" ] }
+serde = { version= "1.0.88", features= [ "derive" ], default-features = false }
 url = "1.7.2"
 num-derive = "0.2.4"
 num-traits = "0.2.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tokio =  {version = "0.2", features = ["full"]}
 tokio-util = {version = "0.2", features = ["codec", "udp"]}
 futures = "0.3"
 bytes = "0.5"
-coap-lite = "0.3.5"
+coap-lite = "^0.4"
 
 [dev-dependencies]
 quickcheck = "0.8.2"


### PR DESCRIPTION
The 0.4 version of coap-lite [adds support for coap-message compatibility](https://github.com/martindisch/coap-lite/pull/7).

serde is slimmed down as it'd cause troubles with new applications that become possible with this.