### PR TITLE
Fixed buffer clearing in message decoding

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -21,11 +21,14 @@ impl Decoder for Codec {
         if buf.len() == 0 {
             return Ok(None);
         }
-        let packet = Ok(Some(Packet::from_bytes(buf).map_err(|cause| {
-            io::Error::new(io::ErrorKind::InvalidData, cause.to_string())
-        })?));
+        let result = (|| {
+            let packet = Ok(Some(Packet::from_bytes(buf).map_err(|cause| {
+                io::Error::new(io::ErrorKind::InvalidData, cause.to_string())
+            })?));
+            packet
+        })();
         buf.clear();
-        packet
+        result
     }
 }
 


### PR DESCRIPTION
When a faulty packet is received, the buffer was not cleared and the faulty buffer content caused to throw the 
`select error: Custom { kind: InvalidData, error: "CoAP error: invalid token length" }` 
in a loop without an end.

This pull request fixes this behaviour and clears the buffer also in case of error result.
It uses a lambda to emulate a `try{}finally{}` block with `buf.clear();` in the `finally` statement.