### PR TITLE
Upgrade to coap-lite 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio-util = {version = "^0.6", features = ["codec","net"]}
 tokio-stream = {version = "^0.1", features = ["time"]}
 futures = "^0.3"
 bytes = "^1.1"
-coap-lite = "^0.7"
+coap-lite = "^0.8"
 
 [dev-dependencies]
 quickcheck = "0.8.2"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,9 @@
 install:
-  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-gnu.exe'
-  - rust-nightly-i686-pc-windows-gnu.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
-  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
-  - SET PATH=%PATH%;C:\MinGW\bin
-  - rustc -V
-  - cargo -V
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init -yv --default-toolchain nightly --default-host x86_64-pc-windows-gnu
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - rustc -vV
+  - cargo -vV
 
 build: false
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -202,9 +202,7 @@ impl CoAPClient {
         // TODO: support observe multi resources at the same time
         let mut message_id: u16 = 0;
         let mut register_packet = CoapRequest::new();
-        register_packet
-            .message
-            .set_observe(vec![ObserveOption::Register as u8]);
+        register_packet.set_observe_flag(ObserveOption::Register);
         register_packet.message.header.message_id = Self::gen_message_id(&mut message_id);
         register_packet.set_path(resource_path);
 
@@ -238,7 +236,7 @@ impl CoAPClient {
                         let mut packet = Packet::new();
                         packet.header.set_type(response.message.header.get_type());
                         packet.header.message_id = response.message.header.message_id;
-                        packet.set_token(response.message.get_token().clone());
+                        packet.set_token(response.message.get_token().into());
 
                         match Self::send_with_socket(&socket, &peer_addr, &packet) {
                             Ok(_) => (),
@@ -261,9 +259,7 @@ impl CoAPClient {
                     let mut deregister_packet = CoapRequest::<SocketAddr>::new();
                     deregister_packet.message.header.message_id =
                         Self::gen_message_id(&mut message_id);
-                    deregister_packet
-                        .message
-                        .set_observe(vec![ObserveOption::Deregister as u8]);
+                    deregister_packet.set_observe_flag(ObserveOption::Deregister);
                     deregister_packet.set_path(observe_path.as_str());
 
                     Self::send_with_socket(&socket, &peer_addr, &deregister_packet.message)

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -419,7 +419,7 @@ mod test {
     async fn request_handler(req: CoapRequest<SocketAddr>) -> Option<CoapResponse> {
         match req.get_method() {
             &coap_lite::RequestType::Get => {
-                let observe_option = req.message.get_observe_value().unwrap();
+                let observe_option = req.get_observe_flag().unwrap().unwrap();
                 assert_eq!(observe_option, ObserveOption::Deregister);
             }
             &coap_lite::RequestType::Put => {}


### PR DESCRIPTION
This new release contains a few minor API improvements, however
it also fixes #70 by upgrading to proper Option uint parsing support.