### PR TITLE
Drop async_closures feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ coap = "0.11"
 
 ### Server:
 ```rust
-#![feature(async_closure)]
-
 use coap_lite::{RequestType as Method};
 use coap::Server;
 use tokio::runtime::Runtime;
@@ -41,7 +39,7 @@ fn main() {
         let mut server = Server::new(addr).unwrap();
         println!("Server up on {}", addr);
         
-        server.run(async move |request| {
+        server.run(|request| async {
             match request.get_method() {
                 &Method::Get => println!("request by get {}", request.get_path()),
                 &Method::Post => println!("request by post {}", String::from_utf8(request.message.payload).unwrap()),

--- a/examples/client_and_server.rs
+++ b/examples/client_and_server.rs
@@ -1,5 +1,3 @@
-#![feature(async_closure)]
-
 extern crate coap;
 
 use coap::{CoAPClient, Server};
@@ -12,7 +10,7 @@ fn main() {
             let mut server = Server::new("127.0.0.1:5683").unwrap();
 
             server
-                .run(async move |request| {
+                .run(|request| async {
                     let uri_path = request.get_path().to_string();
 
                     return match request.response {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,5 +1,3 @@
-#![feature(async_closure)]
-
 extern crate coap;
 
 use coap::Server;
@@ -14,7 +12,7 @@ fn main() {
         println!("Server up on {}", addr);
 
         server
-            .run(async move |request| {
+            .run(|request| async {
                 match request.get_method() {
                     &Method::Get => println!("request by get {}", request.get_path()),
                     &Method::Post => println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,6 @@
 //!
 //! ## Server:
 //! ```no_run
-//! #![feature(async_closure)]
-//!
 //! extern crate coap;
 //!
 //! use coap_lite::{RequestType as Method};
@@ -42,7 +40,7 @@
 //!         let mut server = Server::new(addr).unwrap();
 //!         println!("Server up on {}", addr);
 //!
-//!         server.run(async move |request| {
+//!         server.run(|request| async {
 //!             match request.get_method() {
 //!                 &Method::Get => println!("request by get {}", request.get_path()),
 //!                 &Method::Post => println!("request by post {}", String::from_utf8(request.message.payload).unwrap()),


### PR DESCRIPTION
This feature wasn't actually required to make the library work and I can
see no advantage to encouraging it's usage.

See here for an explanation: https://www.reddit.com/r/rust/comments/n8jn6p/difference_betweenasync_and_async/