### PR TITLE
[RFC] rework requests and observe

### DIFF
--- a/examples/echo_with_dtls.rs
+++ b/examples/echo_with_dtls.rs
@@ -3,6 +3,7 @@
 extern crate coap;
 use coap::client::CoAPClient;
 use coap::dtls::DtlsConfig;
+use coap::request::RequestBuilder;
 use coap::Server;
 use coap_lite::{CoapRequest, RequestType as Method};
 use std::future::Future;
@@ -72,10 +73,11 @@ async fn main() {
         .await
         .expect("could not create client");
     let domain = format!("127.0.0.1:{}", server_port);
-    let resp = client
-        .request_path("/hello", Method::Get, None, None, Some(domain.to_string()))
-        .await
-        .unwrap();
+
+    let request = RequestBuilder::new("/hello", Method::Get)
+        .domain(domain.to_string())
+        .build();
+    let resp = client.send(request).await.unwrap();
     println!(
         "receive on client:  {}",
         std::str::from_utf8(&resp.message.payload).unwrap()

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "dtls")]
 use crate::dtls::{DtlsConfig, DtlsConnection};
+use crate::request::RequestBuilder;
 use alloc::string::String;
 use alloc::vec::Vec;
 use coap_lite::{
@@ -110,7 +111,7 @@ impl<T: Transport> ClientTransport<T> {
             return Ok(p);
         }
         let p = self.receive_internal_no_cache().await?;
-        let (packet, addr) = &p;
+        let (packet, _) = &p;
         self.intercept_packet_for_acks(packet).await;
         return Ok(p);
     }
@@ -343,9 +344,12 @@ impl<T: Transport + 'static> CoAPClient<T> {
     ) -> IoResult<CoapResponse> {
         let (domain, port, path, queries) = Self::parse_coap_url(url)?;
         let mut client = UdpCoAPClient::new_udp((domain.as_str(), port)).await?;
-        client
-            .request_path(&path, method, data, queries, Some(domain))
-            .await
+        let request = RequestBuilder::new(&path, method)
+            .queries(queries)
+            .domain(domain)
+            .data(data)
+            .build();
+        client.send(request).await
     }
 
     /// Execute a single request (GET, POST, PUT, DELETE) with a coap url and a specfic timeout
@@ -358,62 +362,21 @@ impl<T: Transport + 'static> CoAPClient<T> {
     ) -> IoResult<CoapResponse> {
         let (domain, port, path, queries) = Self::parse_coap_url(url)?;
         let mut client = UdpCoAPClient::new_udp((domain.as_str(), port)).await?;
-        client
-            .request_path_with_timeout(&path, method, data, queries, Some(domain), timeout)
-            .await
-    }
+        client.set_receive_timeout(timeout);
+        let request = RequestBuilder::new(&path, method)
+            .queries(queries)
+            .domain(domain)
+            .data(data)
+            .build();
 
-    /// Execute a request (GET, POST, PUT, DELETE) using the given transport
-    pub async fn request_path(
-        &mut self,
-        path: &str,
-        method: Method,
-        data: Option<Vec<u8>>,
-        queries: Option<Vec<u8>>,
-        domain: Option<String>,
-    ) -> IoResult<CoapResponse> {
-        self.request_path_with_timeout(path, method, data, queries, domain, self.transport.timeout)
-            .await
-    }
-
-    /// Execute a request (GET, POST, PUT, DELETE) with a specfic timeout using the given transport. This method will
-    /// try to use block1 requests with a block size of 1024 by default.
-    pub async fn request_path_with_timeout(
-        &mut self,
-        path: &str,
-        method: Method,
-        data: Option<Vec<u8>>,
-        queries: Option<Vec<u8>>,
-        domain: Option<String>,
-        timeout: Duration,
-    ) -> IoResult<CoapResponse> {
-        let mut request = CoapRequest::new();
-        request.set_method(method);
-        request.set_path(path);
-        if let Some(q) = queries {
-            request.message.add_option(CoapOption::UriQuery, q);
-        }
-        if let Some(d) = domain {
-            request
-                .message
-                .add_option(CoapOption::UriHost, d.as_str().as_bytes().to_vec());
-        }
-        request.message.header.message_id = Self::gen_message_id(&mut self.message_id);
-        match data {
-            Some(data) => request.message.payload = data,
-            None => (),
-        }
-        self.set_receive_timeout(timeout);
-        self.perform_request(request).await
+        client.send(request).await
     }
 
     /// Send a Request via the given transport, and receive a response.
     /// users are responsible for filling meaningful fields in the request
     /// this method supports blockwise requests
-    pub async fn perform_request(
-        &mut self,
-        mut request: CoapRequest<SocketAddr>,
-    ) -> IoResult<CoapResponse> {
+    /// use RequestBuilder to build requests to send
+    pub async fn send(&mut self, mut request: CoapRequest<SocketAddr>) -> IoResult<CoapResponse> {
         self.send_request(&mut request).await?;
         self.receive(&mut request).await
     }
@@ -443,31 +406,21 @@ impl<T: Transport + 'static> CoAPClient<T> {
     where
         T: 'static + Send + Sync,
     {
-        // TODO: support observe multi resources at the same time
-        let mut message_id = Self::gen_message_id(&mut self.message_id);
+        let register_packet = RequestBuilder::new(resource_path, Method::Get).build();
 
-        let request_factory = move || {
-            let mut register_packet = CoapRequest::new();
-            register_packet.message.header.message_id = Self::gen_message_id(&mut message_id);
-            register_packet.set_path(&resource_path);
-            register_packet
-        };
         self.set_receive_timeout(timeout);
-        self.observe_with_factory(request_factory, handler).await
+        self.observe_with(register_packet, handler).await
     }
 
-    /// observe a resource with a given transport using your own function to
-    /// generate requests. Use this method if you need to set some specific options in your
+    /// observe a resource with a given transport using your own request
+    /// Use this method if you need to set some specific options in your
     /// requests. This method will add observe flags and a message id as a fallback
-    pub async fn observe_with_factory<
-        Fac: FnOnce() -> CoapRequest<SocketAddr>,
-        H: FnMut(Packet) + Send + 'static,
-    >(
+    pub async fn observe_with<H: FnMut(Packet) + Send + 'static>(
         mut self,
-        factory: Fac,
+        request: CoapRequest<SocketAddr>,
         mut handler: H,
     ) -> IoResult<oneshot::Sender<ObserveMessage>> {
-        let mut register_packet = factory();
+        let mut register_packet = request;
         if 0 == register_packet.message.header.message_id {
             register_packet.message.header.message_id = Self::gen_message_id(&mut self.message_id);
         }
@@ -842,7 +795,16 @@ mod test {
         let domain = "coap.me";
         let mut client = UdpCoAPClient::new_udp((domain, 5683)).await.unwrap();
         let resp = client
-            .request_path("/hello", Method::Get, None, None, Some(domain.to_string()))
+            .send(
+                RequestBuilder::request_path(
+                    "/hello",
+                    Method::Get,
+                    None,
+                    None,
+                    Some(domain.to_string()),
+                )
+                .build(),
+            )
             .await
             .unwrap();
         assert_eq!(resp.message.payload, b"world".to_vec());
@@ -864,12 +826,15 @@ mod test {
         let domain = "coap.me";
         let mut client = UdpCoAPClient::new_udp((domain, 5683)).await.unwrap();
         let resp = client
-            .request_path(
-                "/validate",
-                Method::Post,
-                Some(b"world".to_vec()),
-                None,
-                Some(domain.to_string()),
+            .send(
+                RequestBuilder::request_path(
+                    "/validate",
+                    Method::Post,
+                    Some(b"world".to_vec()),
+                    None,
+                    Some(domain.to_string()),
+                )
+                .build(),
             )
             .await
             .unwrap();
@@ -893,12 +858,11 @@ mod test {
         let domain = "coap.me";
         let mut client = UdpCoAPClient::new_udp((domain, 5683)).await.unwrap();
         let resp = client
-            .request_path(
-                "/create1",
-                Method::Put,
-                Some(b"world".to_vec()),
-                None,
-                Some(domain.to_string()),
+            .send(
+                RequestBuilder::new("/create1", Method::Put)
+                    .data(Some(b"world".to_vec()))
+                    .domain(domain.to_string())
+                    .build(),
             )
             .await
             .unwrap();
@@ -922,12 +886,10 @@ mod test {
         let domain = "coap.me";
         let mut client = UdpCoAPClient::new_udp((domain, 5683)).await.unwrap();
         let resp = client
-            .request_path(
-                "/validate",
-                Method::Delete,
-                None,
-                None,
-                Some(domain.to_string()),
+            .send(
+                RequestBuilder::new("/validate", Method::Delete)
+                    .domain(domain.to_string())
+                    .build(),
             )
             .await
             .unwrap();
@@ -979,12 +941,11 @@ mod test {
         let domain = "coap.me";
         let mut client = UdpCoAPClient::new_udp((domain, 5683)).await.unwrap();
         let resp = client
-            .request_path(
-                "/large-create",
-                Method::Put,
-                Some(large_payload.clone()),
-                None,
-                Some(domain.to_string()),
+            .send(
+                RequestBuilder::new("/large-create", Method::Put)
+                    .domain(domain.to_string())
+                    .data(Some(large_payload.clone()))
+                    .build(),
             )
             .await;
         let err = resp.unwrap_err();
@@ -993,12 +954,11 @@ mod test {
         client.set_block1_size(10_000_000);
 
         let resp = client
-            .request_path(
-                "/large-create",
-                Method::Post,
-                Some(large_payload.clone()),
-                None,
-                Some(domain.to_string()),
+            .send(
+                RequestBuilder::new("/large-create", Method::Post)
+                    .data(Some(large_payload.clone()))
+                    .domain(domain.to_string())
+                    .build(),
             )
             .await
             .unwrap();
@@ -1083,22 +1043,18 @@ mod test {
             ClientTransport::<FaultyUdp>::DEFAULT_NUM_RETRIES as u32 + 1,
         )
         .await;
-        let error = client
-            .request_path("/Rust", Method::Get, None, None, Some(server_addr.clone()))
-            .await
-            .unwrap_err();
+        let request_gen = || {
+            RequestBuilder::new("/Rust", Method::Get)
+                .domain(server_addr.clone())
+                .build()
+        };
+        let error = client.send(request_gen()).await.unwrap_err();
         assert_eq!(error.kind(), ErrorKind::TimedOut);
         //this request will work, we do this to reset the state of the faulty udp
-        client
-            .request_path("/Rust", Method::Get, None, None, Some(server_addr.clone()))
-            .await
-            .unwrap();
+        client.send(request_gen()).await.unwrap();
 
         client.set_transport_retries(ClientTransport::<UdpTransport>::DEFAULT_NUM_RETRIES + 2);
-        let resp = client
-            .request_path("/Rust", Method::Get, None, None, Some(server_addr))
-            .await
-            .unwrap();
+        let resp = client.send(request_gen()).await.unwrap();
 
         assert_eq!(resp.message.payload, b"Rust".to_vec());
     }
@@ -1120,7 +1076,7 @@ mod test {
         request.message.header.message_id = 123;
         request.message.header.set_type(MessageType::NonConfirmable);
 
-        let req = client.perform_request(request).await;
+        let req = client.send(request).await;
         assert!(req.is_err());
     }
 }

--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -139,6 +139,7 @@ pub struct DtlsConfig {
 mod test {
     use super::*;
     use crate::client::CoAPClient;
+    use crate::request::RequestBuilder;
     use crate::server::UdpCoapListener;
     use crate::{Server, UdpCoAPClient};
     use coap_lite::{CoapOption, CoapRequest, RequestType as Method};
@@ -326,7 +327,16 @@ mod test {
             .expect("could not create client");
         let domain = format!("127.0.0.1:{}", server_port);
         let resp = client
-            .request_path("/hello", Method::Get, None, None, Some(domain.to_string()))
+            .send(
+                RequestBuilder::request_path(
+                    "/hello",
+                    Method::Get,
+                    None,
+                    None,
+                    Some(domain.to_string()),
+                )
+                .build(),
+            )
             .await
             .unwrap();
         assert_eq!(resp.message.payload, b"hello".to_vec());
@@ -353,7 +363,16 @@ mod test {
             .expect("could not create client");
         let domain = format!("127.0.0.1:{}", server_port);
         let resp = client
-            .request_path("/hello", Method::Get, None, None, Some(domain.to_string()))
+            .send(
+                RequestBuilder::request_path(
+                    "/hello",
+                    Method::Get,
+                    None,
+                    None,
+                    Some(domain.to_string()),
+                )
+                .build(),
+            )
             .await
             .unwrap();
         assert_eq!(resp.message.payload, b"hello".to_vec());
@@ -413,7 +432,16 @@ mod test {
             .expect("could not create client");
         let domain = format!("127.0.0.1:{}", server_port);
         let resp = client
-            .request_path("/hello", Method::Get, None, None, Some(domain.to_string()))
+            .send(
+                RequestBuilder::request_path(
+                    "/hello",
+                    Method::Get,
+                    None,
+                    None,
+                    Some(domain.to_string()),
+                )
+                .build(),
+            )
             .await
             .unwrap();
         assert_eq!(resp.message.payload, b"hello".to_vec());
@@ -460,12 +488,15 @@ mod test {
             .expect("could not create client");
         let domain = format!("127.0.0.1:{}", dtls);
         let resp = client
-            .request_path(
-                "/hello_dtls",
-                Method::Get,
-                None,
-                None,
-                Some(domain.to_string()),
+            .send(
+                RequestBuilder::request_path(
+                    "/hello_dtls",
+                    Method::Get,
+                    None,
+                    None,
+                    Some(domain.to_string()),
+                )
+                .build(),
             )
             .await
             .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,4 +95,5 @@ pub mod client;
 #[cfg(feature = "dtls")]
 pub mod dtls;
 mod observer;
+pub mod request;
 pub mod server;

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,0 +1,197 @@
+use std::net::SocketAddr;
+
+pub use coap_lite::{
+    CoapOption, CoapRequest, MessageClass, MessageType, ObserveOption, Packet,
+    RequestType as Method, ResponseType as Status,
+};
+
+/// A builder for creating CoAP requests using coap_lite
+pub struct RequestBuilder<'a> {
+    path: &'a str,
+    method: Method,
+    data: Option<Vec<u8>>,
+    queries: Option<Vec<u8>>,
+    domain: String,
+    confirmable: bool,
+    token: Option<Vec<u8>>,
+    options: Vec<(CoapOption, Vec<u8>)>,
+}
+impl<'a> RequestBuilder<'a> {
+    pub fn new(path: &'a str, method: Method) -> Self {
+        Self {
+            path,
+            method,
+            data: None,
+            queries: None,
+            token: None,
+            domain: "".to_string(),
+            confirmable: true,
+            options: vec![],
+        }
+    }
+
+    /// Create a new request with the given path, method, optional payload, optional query, and
+    /// domain.
+    pub fn request_path(
+        path: &'a str,
+        method: Method,
+        payload: Option<Vec<u8>>,
+        query: Option<Vec<u8>>,
+        domain: Option<String>,
+    ) -> Self {
+        let new_self = Self::new(path, method);
+        Self {
+            data: payload,
+            queries: query,
+            domain: domain.unwrap_or_else(|| "".to_string()),
+            ..new_self
+        }
+    }
+
+    /// Set the payload of the request.
+    pub fn data(mut self, data: Option<Vec<u8>>) -> Self {
+        self.data = data;
+        self
+    }
+    /// set the queries of the request.
+    pub fn queries(mut self, queries: Option<Vec<u8>>) -> Self {
+        self.queries = queries;
+        self
+    }
+    /// set the domain of the request.
+    pub fn domain(mut self, domain: String) -> Self {
+        self.domain = domain;
+        self
+    }
+    /// set whether the request is confirmable.
+    pub fn confirmable(mut self, confirmable: bool) -> Self {
+        self.confirmable = confirmable;
+        self
+    }
+    /// set the token of the request
+    pub fn token(mut self, token: Option<Vec<u8>>) -> Self {
+        self.token = token;
+        self
+    }
+    /// set the options of the request
+    pub fn options(mut self, options: Vec<(CoapOption, Vec<u8>)>) -> Self {
+        self.options = options;
+        self
+    }
+
+    pub fn build(self) -> CoapRequest<SocketAddr> {
+        let mut request = CoapRequest::new();
+        request.set_method(self.method);
+        request.set_path(self.path);
+        if let Some(queries) = self.queries {
+            request.message.add_option(CoapOption::UriQuery, queries);
+        }
+        for (opt, opt_data) in self.options {
+            assert_ne!(opt, CoapOption::UriQuery, "Use queries instead");
+            request.message.add_option(opt, opt_data);
+        }
+        if self.domain.len() != 0 {
+            request.message.add_option(
+                CoapOption::UriHost,
+                self.domain.as_str().as_bytes().to_vec(),
+            );
+        }
+        if let Some(data) = self.data {
+            request.message.payload = data;
+        }
+        match self.confirmable {
+            true => request.message.header.set_type(MessageType::Confirmable),
+            false => request.message.header.set_type(MessageType::NonConfirmable),
+        };
+        if let Some(tok) = self.token {
+            request.message.set_token(tok);
+        }
+        return request;
+    }
+}
+#[cfg(test)]
+pub mod test {
+    pub use super::*;
+
+    #[test]
+    fn test_request_has_payload() {
+        let build = RequestBuilder::request_path(
+            "/",
+            Method::Put,
+            Some(b"hello, world!".to_vec()),
+            None,
+            None,
+        )
+        .build();
+        assert_eq!(build.message.payload.as_slice(), b"hello, world!");
+    }
+    #[test]
+    fn test_domain() {
+        let build = RequestBuilder::request_path(
+            "/",
+            Method::Put,
+            None,
+            None,
+            Some("example.com".to_string()),
+        )
+        .build();
+        assert_eq!(
+            build.message.get_first_option(CoapOption::UriHost).unwrap(),
+            b"example.com"
+        );
+    }
+
+    #[test]
+    fn test_domain_and_other_options() {
+        let options = vec![
+            (CoapOption::ProxyUri, b"coap://foo.com".to_vec()),
+            (CoapOption::Block2, b"fake".to_vec()),
+        ];
+        let build = RequestBuilder::request_path(
+            "/",
+            Method::Put,
+            None,
+            b"query=hello".to_vec().into(),
+            Some("example.com".to_string()),
+        )
+        .options(options)
+        .build();
+        assert_eq!(
+            build.message.get_first_option(CoapOption::UriHost).unwrap(),
+            b"example.com"
+        );
+        assert_eq!(
+            build
+                .message
+                .get_first_option(CoapOption::UriQuery)
+                .unwrap(),
+            b"query=hello"
+        );
+        assert_eq!(
+            build
+                .message
+                .get_first_option(CoapOption::ProxyUri)
+                .unwrap(),
+            b"coap://foo.com"
+        );
+        assert_eq!(
+            build.message.get_first_option(CoapOption::Block2).unwrap(),
+            b"fake"
+        )
+    }
+
+    #[test]
+    fn test_request_token() {
+        let build = RequestBuilder::new("/", Method::Put)
+            .token(Some(b"token".to_vec()))
+            .build();
+        assert_eq!(build.message.get_token(), b"token");
+    }
+    #[test]
+    fn test_confirmable_request() {
+        let build = RequestBuilder::new("/", Method::Put)
+            .confirmable(true)
+            .build();
+        assert_eq!(build.message.header.get_type(), MessageType::Confirmable);
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -445,6 +445,8 @@ impl Server {
 
 #[cfg(test)]
 pub mod test {
+    use crate::request::RequestBuilder;
+
     use super::super::*;
     use super::*;
     use coap_lite::{block_handler::BlockValue, CoapOption, RequestType};
@@ -589,17 +591,12 @@ pub mod test {
         let server_string = format!("127.0.0.1:{}", server_port);
         let mut client = UdpCoAPClient::new_udp(server_string.clone()).await.unwrap();
 
-        let resp = client
-            .request_path(
-                "/large",
-                RequestType::Put,
-                Some(v),
-                None,
-                Some(server_string.clone()),
-            )
-            .await
-            .unwrap();
-        //assert_eq!(resp.message.payload, b"Created".to_vec());
+        let request = RequestBuilder::new("/large", RequestType::Put)
+            .data(Some(v))
+            .domain(server_string.clone())
+            .build();
+
+        let resp = client.send(request).await.unwrap();
         let block_opt = resp
             .message
             .get_first_option_as::<BlockValue>(CoapOption::Block1)


### PR DESCRIPTION
- requests are now "built" using a request builder
- observe uses a request instead of a factory
- added request_path to request builder as a fallback for old methods

Advantages are that requests are now easy to extend for the client without having to write super long methods

I took the liberty to clean up some old methods and remove them. Let me know if this a good idea (I think it's a nice time to clean up since there is no new release)