### PR TITLE
improved dtls construction, fix resource leak on recv_loop, update version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coap"
-version = "0.16.0"
+version = "0.17.0"
 description = "A CoAP library"
 readme = "README.md"
 documentation = "https://docs.rs/coap/"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ First add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-coap = "0.16"
+coap = "0.17"
 coap-lite = "0.11.3"
 tokio = {version = "^1.32", features = ["full"]}
 ```

--- a/examples/echo_with_dtls.rs
+++ b/examples/echo_with_dtls.rs
@@ -2,7 +2,7 @@
 /// a look at the test in dtls.rs
 extern crate coap;
 use coap::client::CoAPClient;
-use coap::dtls::DtlsConfig;
+use coap::dtls::UdpDtlsConfig;
 use coap::request::RequestBuilder;
 use coap::Server;
 use coap_lite::{CoapRequest, RequestType as Method};
@@ -60,7 +60,7 @@ async fn main() {
     .await
     .unwrap();
 
-    let dtls_config = DtlsConfig {
+    let dtls_config = UdpDtlsConfig {
         config,
         dest_addr: ("127.0.0.1", server_port)
             .to_socket_addrs()
@@ -69,7 +69,7 @@ async fn main() {
             .unwrap(),
     };
 
-    let client = CoAPClient::from_dtls_config(dtls_config)
+    let client = CoAPClient::from_udp_dtls_config(dtls_config)
         .await
         .expect("could not create client");
     let domain = format!("127.0.0.1:{}", server_port);

--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -1,18 +1,19 @@
 //! this file is included by enabling the "dtls" feature. It provides a default DTLS backend using
 //! webrtc-rs's dtls implementation.
-use crate::client::Transport;
+use crate::client::ClientTransport;
 use crate::server::{Listener, Responder, TransportRequestSender};
 use async_trait::async_trait;
 use std::net::SocketAddr;
 use std::time::Duration;
 use std::{
-    io::{Error, ErrorKind, Result},
+    io::{Error, ErrorKind, Result as IoResult},
     sync::Arc,
 };
 use tokio::net::UdpSocket;
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use webrtc_dtls::conn::DTLSConn;
+use webrtc_dtls::state::State;
 use webrtc_util::conn::{Conn, Listener as WebRtcListener};
 
 #[async_trait]
@@ -20,7 +21,7 @@ impl<L: WebRtcListener + Send + 'static> Listener for L {
     async fn listen(
         self: Box<Self>,
         sender: TransportRequestSender,
-    ) -> std::io::Result<JoinHandle<std::io::Result<()>>> {
+    ) -> IoResult<JoinHandle<IoResult<()>>> {
         Ok(tokio::spawn(async move {
             loop {
                 let res = self.accept().await;
@@ -40,18 +41,17 @@ pub struct DtlsResponse {
 }
 
 #[async_trait]
-impl Transport for DtlsConnection {
-    async fn recv(&self, buf: &mut [u8]) -> std::io::Result<(usize, SocketAddr)> {
+impl ClientTransport for DtlsConnection {
+    async fn recv(&self, buf: &mut [u8]) -> IoResult<usize> {
         let read = self
             .conn
             .read(buf, None)
             .await
             .map_err(|e| Error::new(ErrorKind::Other, e))?;
-        let from = self.peer_addr;
-        return Ok((read, from));
+        return Ok(read);
     }
 
-    async fn send(&self, buf: &[u8]) -> std::io::Result<usize> {
+    async fn send(&self, buf: &[u8]) -> IoResult<usize> {
         self.conn
             .write(buf, None)
             .await
@@ -96,38 +96,35 @@ pub async fn spawn_webrtc_conn(
         };
     }
 }
-
+#[async_trait]
+/// This trait is used to implement a hook that is called when a DTLS connection is dropped
+/// Only use this in case you need to save your connection
+pub trait DtlsDropHook: Send + Sync {
+    async fn on_drop(&self, conn: Arc<DTLSConn>);
+}
 pub struct DtlsConnection {
-    pub conn: DTLSConn,
-    pub peer_addr: SocketAddr,
+    conn: Arc<DTLSConn>,
+    on_drop: Option<Box<dyn DtlsDropHook>>,
 }
 
 impl DtlsConnection {
-    /// create a DTLS client connection from a socket. This function will attempt to perform a DTLS
-    /// hanshake
+    /// Creates a new DTLS connection from a given connection. This connection can be  
+    /// a tokio UDP socket or a user-created struct implementing Conn, Send, and Sync
+    ///
     ///
     /// # Errors
     ///
-    /// This function will return an error if .
-    /// socket cannot connect to `dest_addr` specified in dtls_config or
-    /// handshake times out in the given timeout duration
-    pub async fn from_udp_socket(
-        socket: UdpSocket,
-        dtls_config: DtlsConfig,
-        handshake_timeout: Duration,
-    ) -> Result<Self> {
-        socket.connect(dtls_config.dest_addr).await?;
-        return Self::from_connection(Arc::new(socket), dtls_config, handshake_timeout).await;
-    }
-
-    pub async fn from_connection(
+    /// This function will return an error if the handshake fails or if it times out
+    pub async fn try_from_connection(
         connection: Arc<dyn Conn + Send + Sync>,
-        dtls_config: DtlsConfig,
+        dtls_config: webrtc_dtls::config::Config,
         handshake_timeout: Duration,
-    ) -> Result<Self> {
+        state: Option<State>,
+        on_drop: Option<Box<dyn DtlsDropHook>>,
+    ) -> IoResult<Self> {
         let dtls_conn = timeout(
             handshake_timeout,
-            DTLSConn::new(connection, dtls_config.config, true, None),
+            DTLSConn::new(connection, dtls_config, true, state),
         )
         .await
         .map_err(|_| {
@@ -138,21 +135,43 @@ impl DtlsConnection {
         })?
         .map_err(|e| Error::new(ErrorKind::Other, e))?;
         return Ok(DtlsConnection {
-            conn: dtls_conn,
-            peer_addr: dtls_config.dest_addr,
+            conn: Arc::new(dtls_conn),
+            on_drop,
         });
     }
 
-    pub async fn try_new(dtls_config: DtlsConfig) -> Result<DtlsConnection> {
+    pub async fn try_new(dtls_config: UdpDtlsConfig) -> IoResult<DtlsConnection> {
         let conn = UdpSocket::bind("0.0.0.0:0")
             .await
             .map_err(|e| Error::new(ErrorKind::Other, e))?;
-        return Self::from_udp_socket(conn, dtls_config, Duration::new(30, 0)).await;
+        conn.connect(dtls_config.dest_addr).await?;
+        return Self::try_from_connection(
+            Arc::new(conn),
+            dtls_config.config,
+            Duration::new(30, 0),
+            None,
+            None,
+        )
+        .await;
     }
 }
-pub struct DtlsConfig {
+pub struct UdpDtlsConfig {
     pub config: webrtc_dtls::config::Config,
     pub dest_addr: SocketAddr,
+}
+
+impl Drop for DtlsConnection {
+    fn drop(&mut self) {
+        if let Some(drop_hook) = self.on_drop.take() {
+            println!("dropping");
+            //this is a nasty hack necessary to call async methods inside the drop method without
+            //transferring ownership
+            let conn = self.conn.clone();
+            tokio::spawn(async move {
+                drop_hook.on_drop(conn).await;
+            });
+        }
+    }
 }
 
 #[cfg(test)]
@@ -169,7 +188,9 @@ mod test {
     use std::fs::File;
     use std::io::{BufReader, Read};
     use std::net::{SocketAddr, ToSocketAddrs};
+    use std::sync::atomic::AtomicBool;
     use tokio::sync::mpsc;
+    use tokio::time::sleep;
     use webrtc_dtls::cipher_suite::CipherSuiteId;
     use webrtc_dtls::config::{ClientAuthType, Config, ExtendedMasterSecretType};
     use webrtc_dtls::crypto::{Certificate, CryptoPrivateKey};
@@ -333,7 +354,7 @@ mod test {
             .await
             .unwrap();
 
-        let dtls_config = DtlsConfig {
+        let dtls_config = UdpDtlsConfig {
             config: client_cfg,
             dest_addr: ("127.0.0.1", server_port)
                 .to_socket_addrs()
@@ -342,7 +363,7 @@ mod test {
                 .unwrap(),
         };
 
-        let client = CoAPClient::from_dtls_config(dtls_config)
+        let client = CoAPClient::from_udp_dtls_config(dtls_config)
             .await
             .expect("could not create client");
         let domain = format!("127.0.0.1:{}", server_port);
@@ -369,7 +390,7 @@ mod test {
             .await
             .unwrap();
 
-        let dtls_config = DtlsConfig {
+        let dtls_config = UdpDtlsConfig {
             config,
             dest_addr: ("127.0.0.1", server_port)
                 .to_socket_addrs()
@@ -378,7 +399,7 @@ mod test {
                 .unwrap(),
         };
 
-        let client = CoAPClient::from_dtls_config(dtls_config)
+        let client = CoAPClient::from_udp_dtls_config(dtls_config)
             .await
             .expect("could not create client");
         let domain = format!("127.0.0.1:{}", server_port);
@@ -407,7 +428,7 @@ mod test {
         // make the psk fail
         config.psk = Some(Arc::new(|_| Ok(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 9])));
 
-        let dtls_config = DtlsConfig {
+        let dtls_config = UdpDtlsConfig {
             config,
             dest_addr: ("127.0.0.1", server_port)
                 .to_socket_addrs()
@@ -416,7 +437,7 @@ mod test {
                 .unwrap(),
         };
         assert!(
-            CoAPClient::from_dtls_config(dtls_config).await.is_err(),
+            CoAPClient::from_udp_dtls_config(dtls_config).await.is_err(),
             "should not have connected"
         );
     }
@@ -438,7 +459,7 @@ mod test {
         let get_error = get.unwrap_err();
         assert!(get_error.kind() == ErrorKind::TimedOut);
 
-        let dtls_config = DtlsConfig {
+        let dtls_config = UdpDtlsConfig {
             config,
             dest_addr: ("127.0.0.1", server_port)
                 .to_socket_addrs()
@@ -447,7 +468,7 @@ mod test {
                 .unwrap(),
         };
 
-        let client = CoAPClient::from_dtls_config(dtls_config)
+        let client = CoAPClient::from_udp_dtls_config(dtls_config)
             .await
             .expect("could not create client");
         let domain = format!("127.0.0.1:{}", server_port);
@@ -494,7 +515,7 @@ mod test {
             .unwrap();
         assert_eq!(get.message.payload, b"hello_udp".to_vec());
 
-        let dtls_config = DtlsConfig {
+        let dtls_config = UdpDtlsConfig {
             config,
             dest_addr: ("127.0.0.1", dtls)
                 .to_socket_addrs()
@@ -503,7 +524,7 @@ mod test {
                 .unwrap(),
         };
 
-        let client = CoAPClient::from_dtls_config(dtls_config)
+        let client = CoAPClient::from_udp_dtls_config(dtls_config)
             .await
             .expect("could not create client");
         let domain = format!("127.0.0.1:{}", dtls);
@@ -521,5 +542,148 @@ mod test {
             .await
             .unwrap();
         assert_eq!(resp.message.payload, b"hello_dtls".to_vec());
+    }
+
+    struct OnDropFlag(pub Arc<AtomicBool>);
+
+    #[async_trait]
+    impl DtlsDropHook for OnDropFlag {
+        async fn on_drop(&self, conn: Arc<DTLSConn>) {
+            let _state = conn.connection_state().await;
+            self.0.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_drop_hook() {
+        let config = get_psk_config();
+        let server_port = spawn_dtls_server("127.0.0.1:0", request_handler, config.clone())
+            .recv()
+            .await
+            .unwrap();
+        let dtls_config = UdpDtlsConfig {
+            config,
+            dest_addr: ("127.0.0.1", server_port)
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .unwrap(),
+        };
+
+        let flag = Arc::new(AtomicBool::new(false));
+        {
+            let socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await.unwrap());
+            socket.connect(dtls_config.dest_addr).await.unwrap();
+            let on_drop = OnDropFlag(flag.clone());
+
+            let transport = DtlsConnection::try_from_connection(
+                socket,
+                dtls_config.config,
+                Duration::from_secs(1),
+                None,
+                Some(Box::new(on_drop)),
+            )
+            .await
+            .expect("could not create client");
+            let client = CoAPClient::from_transport(transport);
+            let domain = format!("127.0.0.1:{}", server_port);
+            let resp = client
+                .send(
+                    RequestBuilder::request_path(
+                        "/hello",
+                        Method::Get,
+                        None,
+                        None,
+                        Some(domain.to_string()),
+                    )
+                    .build(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(resp.message.payload, b"hello".to_vec());
+            drop(client);
+        }
+        sleep(Duration::from_millis(500)).await;
+        assert!(
+            flag.load(std::sync::atomic::Ordering::Relaxed),
+            "flag not called"
+        );
+    }
+
+    struct SocketWrapper(pub UdpSocket);
+
+    type WebrtcResult<T> = std::result::Result<T, webrtc_util::Error>;
+    #[async_trait]
+    impl Conn for SocketWrapper {
+        async fn connect(&self, addr: SocketAddr) -> WebrtcResult<()> {
+            self.0.connect(addr).await;
+            Ok(())
+        }
+        async fn recv(&self, buf: &mut [u8]) -> WebrtcResult<usize> {
+            Ok(self.0.recv(buf).await?)
+        }
+        async fn recv_from(&self, buf: &mut [u8]) -> WebrtcResult<(usize, SocketAddr)> {
+            todo!("not needed")
+        }
+        async fn send(&self, buf: &[u8]) -> WebrtcResult<usize> {
+            Ok(self.0.send(buf).await?)
+        }
+        async fn send_to(&self, buf: &[u8], target: SocketAddr) -> WebrtcResult<usize> {
+            todo!("not needed");
+        }
+        fn local_addr(&self) -> WebrtcResult<SocketAddr> {
+            todo!("not needed");
+        }
+        fn remote_addr(&self) -> Option<SocketAddr> {
+            todo!("not needed")
+        }
+        async fn close(&self) -> WebrtcResult<()> {
+            Ok(self.0.close().await?)
+        }
+    }
+    #[tokio::test]
+    async fn test_own_connection() {
+        let config = get_psk_config();
+        let server_port = spawn_dtls_server("127.0.0.1:0", request_handler, config.clone())
+            .recv()
+            .await
+            .unwrap();
+        let dtls_config = UdpDtlsConfig {
+            config,
+            dest_addr: ("127.0.0.1", server_port)
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .unwrap(),
+        };
+        let socket = Arc::new(SocketWrapper(UdpSocket::bind("0.0.0.0:0").await.unwrap()));
+        socket.connect(dtls_config.dest_addr).await.unwrap();
+
+        let transport = DtlsConnection::try_from_connection(
+            socket,
+            dtls_config.config,
+            Duration::from_secs(1),
+            None,
+            None,
+        )
+        .await
+        .expect("could not create client");
+        let client = CoAPClient::from_transport(transport);
+        let domain = format!("127.0.0.1:{}", server_port);
+        let resp = client
+            .send(
+                RequestBuilder::request_path(
+                    "/hello",
+                    Method::Get,
+                    None,
+                    None,
+                    Some(domain.to_string()),
+                )
+                .build(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.message.payload, b"hello".to_vec());
+        drop(client);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! coap = "0.16"
+//! coap = "0.17"
 //! coap-lite = "0.11.3"
 //! tokio = {version = "^1.32", features = ["full"]}
 //! ```


### PR DESCRIPTION
changelog:
- DTLS can now be used with a custom transport as long as it implements Conn + Send  + Sync
- an "on drop" hook for DTLS may now be used when the client is dropped -> may be used if you want to resume a session, also tested
- Change how DTLS connections are made so users can use their own types, as well as add existing state, also tested
- rename "Transport" to "ClientTransport"  since it is only used by the client
- ClientTransport no longer cares about a Sockaddr return type since it's not needed for the client
- fix issue where a connection would never be dropped because recv_loop would run forever (changed Arc to Weak)
- update version to 0.17 