### PR TITLE
multicast receive address

### DIFF
--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -3,7 +3,7 @@
 use crate::client::ClientTransport;
 use crate::server::{Listener, Responder, TransportRequestSender};
 use async_trait::async_trait;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::SocketAddr;
 use std::time::Duration;
 use std::{
     io::{Error, ErrorKind, Result as IoResult},
@@ -42,14 +42,13 @@ pub struct DtlsResponse {
 
 #[async_trait]
 impl ClientTransport for DtlsConnection {
-    async fn recv(&self, buf: &mut [u8]) -> IoResult<(usize, SocketAddr)> {
+    async fn recv(&self, buf: &mut [u8]) -> IoResult<(usize, Option<SocketAddr>)> {
         let read = self
             .conn
             .read(buf, None)
             .await
             .map_err(|e| Error::new(ErrorKind::Other, e))?;
-
-        return Ok((read, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0)));
+        return Ok((read, self.conn.remote_addr()));
     }
 
     async fn send(&self, buf: &[u8]) -> IoResult<usize> {
@@ -188,7 +187,7 @@ mod test {
     use rcgen::KeyPair;
     use std::fs::File;
     use std::io::{BufReader, Read};
-    use std::net::{SocketAddr, ToSocketAddrs};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
     use std::sync::atomic::AtomicBool;
     use tokio::sync::mpsc;
     use tokio::time::sleep;
@@ -636,7 +635,7 @@ mod test {
             todo!("not needed");
         }
         fn remote_addr(&self) -> Option<SocketAddr> {
-            todo!("not needed")
+            Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0))
         }
         async fn close(&self) -> WebrtcResult<()> {
             Ok(self.0.close().await?)

--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -3,7 +3,7 @@
 use crate::client::ClientTransport;
 use crate::server::{Listener, Responder, TransportRequestSender};
 use async_trait::async_trait;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 use std::{
     io::{Error, ErrorKind, Result as IoResult},
@@ -42,13 +42,14 @@ pub struct DtlsResponse {
 
 #[async_trait]
 impl ClientTransport for DtlsConnection {
-    async fn recv(&self, buf: &mut [u8]) -> IoResult<usize> {
+    async fn recv(&self, buf: &mut [u8]) -> IoResult<(usize, SocketAddr)> {
         let read = self
             .conn
             .read(buf, None)
             .await
             .map_err(|e| Error::new(ErrorKind::Other, e))?;
-        return Ok(read);
+
+        return Ok((read, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0)));
     }
 
     async fn send(&self, buf: &[u8]) -> IoResult<usize> {
@@ -108,7 +109,7 @@ pub struct DtlsConnection {
 }
 
 impl DtlsConnection {
-    /// Creates a new DTLS connection from a given connection. This connection can be  
+    /// Creates a new DTLS connection from a given connection. This connection can be
     /// a tokio UDP socket or a user-created struct implementing Conn, Send, and Sync
     ///
     ///

--- a/src/server.rs
+++ b/src/server.rs
@@ -817,7 +817,7 @@ pub mod test {
         let mut receiver = client.create_receiver_for(&request).await;
         client.send_all_coap(&request, segment).await.unwrap();
         let recv_packet = receiver.receive().await.unwrap();
-        assert_eq!(recv_packet.payload, b"test-echo".to_vec());
+        assert_eq!(recv_packet.packet.payload, b"test-echo".to_vec());
     }
 
     //This test right now does not work on windows
@@ -872,7 +872,7 @@ pub mod test {
         let mut receiver = client.create_receiver_for(&request).await;
         client.send_all_coap(&request, segment).await.unwrap();
         let recv_packet = receiver.receive().await.unwrap();
-        assert_eq!(recv_packet.payload, b"test-echo".to_vec());
+        assert_eq!(recv_packet.packet.payload, b"test-echo".to_vec());
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -817,7 +817,7 @@ pub mod test {
         let mut receiver = client.create_receiver_for(&request).await;
         client.send_all_coap(&request, segment).await.unwrap();
         let recv_packet = receiver.receive().await.unwrap();
-        assert_eq!(recv_packet.packet.payload, b"test-echo".to_vec());
+        assert_eq!(recv_packet.message.payload, b"test-echo".to_vec());
     }
 
     //This test right now does not work on windows
@@ -872,7 +872,7 @@ pub mod test {
         let mut receiver = client.create_receiver_for(&request).await;
         client.send_all_coap(&request, segment).await.unwrap();
         let recv_packet = receiver.receive().await.unwrap();
-        assert_eq!(recv_packet.packet.payload, b"test-echo".to_vec());
+        assert_eq!(recv_packet.message.payload, b"test-echo".to_vec());
     }
 
     #[test]


### PR DESCRIPTION
When using `send_all_coap` and using a `create_receiver_for` receiving all the responses,
we had a requirement to also know where the responses came from.

This fixes that, however I'm not really happy with the exact state of this MR yet.
I'm open for suggestions/improvements to implement!