### PR TITLE
New CoAPClient creator method using a standard socket

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,6 @@ dtls = ["dep:webrtc-dtls", "dep:webrtc-util", "dep:rustls", "dep:rustls-pemfile"
 
 [dev-dependencies]
 quickcheck = "0.8.2"
-
+socket2 = "0.5"
+tokio-test = "0.4.4"
 


### PR DESCRIPTION
In some scenarios it's useful to have control over advanced socket configuration. These advanced settings are available in the socket2 crate. To create CoAPClient instances using sockets with these advanced settings, we need a creator method capable of using standard-socket-compatible socket instance that can be explicitly configured by the API user.

In my scenario I need to set the number of hops for multicast datagrams with scope larger than link-local to allow routing multicast traffic between sub-networks in my site.