### PR TITLE
Add function to send multicast messages to an arbitrary multicast address

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -441,6 +441,15 @@ impl UdpCoAPClient {
             ),
         };
 
+        self.send_multicast(request, &addr).await
+    }
+
+    /// Send a multicast request to multiple devices.
+    pub async fn send_multicast(
+        &self,
+        request: &CoapRequest<SocketAddr>,
+        addr: &SocketAddr,
+    ) -> IoResult<()> {
         match request.message.to_bytes() {
             Ok(bytes) => {
                 let size = self


### PR DESCRIPTION
IPv6 Multicast Address Space Registry defines multiple addresses that can be used for CoAP multicast traffic: CoAP Nodes, CoRE Resource Directories, dynamically allocated addresses according to RFC 3307.

To send multicast messages to these addresses, the API user needs a function in which they can explicitly specify the multicast destination address.