### PR TITLE
Set Block2 M bit to zero in the request

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -974,6 +974,7 @@ impl<T: ClientTransport + 'static> CoAPClient<T> {
                 request.message.clear_option(CoapOption::Block2);
                 let mut next_block2 = block2.clone();
                 next_block2.num += 1;
+                next_block2.more = false;
                 request
                     .message
                     .add_option_as::<BlockValue>(CoapOption::Block2, next_block2);


### PR DESCRIPTION
The current implementation copies the Block2 option from the response, increments the block number, and adds it to the next request in the block transfer. This is done when then M bit in the Block2 option from the response is set, which means that the bit is set when cloned and added back to the request. To be compliant with RFC-7959, set the M bit to zero before adding it back to the request.

Excerpt from RFC-7959:

"In a request, the client MUST set the M bit of a Block2 Option to zero and the server MUST ignore it on reception."

https://datatracker.ietf.org/doc/html/rfc7959#section-2.4