### PR TITLE
Improve URI option decomposition to better match CoAP RFC 7252

### DIFF
--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -373,7 +373,7 @@ mod test {
                     "/hello",
                     Method::Get,
                     None,
-                    None,
+                    vec![],
                     Some(domain.to_string()),
                 )
                 .build(),
@@ -409,7 +409,7 @@ mod test {
                     "/hello",
                     Method::Get,
                     None,
-                    None,
+                    vec![],
                     Some(domain.to_string()),
                 )
                 .build(),
@@ -478,7 +478,7 @@ mod test {
                     "/hello",
                     Method::Get,
                     None,
-                    None,
+                    vec![],
                     Some(domain.to_string()),
                 )
                 .build(),
@@ -534,7 +534,7 @@ mod test {
                     "/hello_dtls",
                     Method::Get,
                     None,
-                    None,
+                    vec![],
                     Some(domain.to_string()),
                 )
                 .build(),
@@ -593,7 +593,7 @@ mod test {
                         "/hello",
                         Method::Get,
                         None,
-                        None,
+                        vec![],
                         Some(domain.to_string()),
                     )
                     .build(),
@@ -676,7 +676,7 @@ mod test {
                     "/hello",
                     Method::Get,
                     None,
-                    None,
+                    vec![],
                     Some(domain.to_string()),
                 )
                 .build(),

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::{net::{IpAddr, SocketAddr}, str::FromStr};
 
 pub use coap_lite::{
     CoapOption, CoapRequest, MessageClass, MessageType, ObserveOption, Packet,
@@ -90,7 +90,7 @@ impl<'a> RequestBuilder<'a> {
             assert_ne!(opt, CoapOption::UriQuery, "Use queries instead");
             request.message.add_option(opt, opt_data);
         }
-        if self.domain.len() != 0 {
+        if self.domain.len() != 0 && IpAddr::from_str(&self.domain).is_err() {
             request.message.add_option(
                 CoapOption::UriHost,
                 self.domain.as_str().as_bytes().to_vec(),

--- a/src/request.rs
+++ b/src/request.rs
@@ -10,7 +10,7 @@ pub struct RequestBuilder<'a> {
     path: &'a str,
     method: Method,
     data: Option<Vec<u8>>,
-    queries: Option<Vec<u8>>,
+    queries: Vec<Vec<u8>>,
     domain: String,
     confirmable: bool,
     token: Option<Vec<u8>>,
@@ -22,7 +22,7 @@ impl<'a> RequestBuilder<'a> {
             path,
             method,
             data: None,
-            queries: None,
+            queries: vec![],
             token: None,
             domain: "".to_string(),
             confirmable: true,
@@ -36,7 +36,7 @@ impl<'a> RequestBuilder<'a> {
         path: &'a str,
         method: Method,
         payload: Option<Vec<u8>>,
-        query: Option<Vec<u8>>,
+        query: Vec<Vec<u8>>,
         domain: Option<String>,
     ) -> Self {
         let new_self = Self::new(path, method);
@@ -54,7 +54,7 @@ impl<'a> RequestBuilder<'a> {
         self
     }
     /// set the queries of the request.
-    pub fn queries(mut self, queries: Option<Vec<u8>>) -> Self {
+    pub fn queries(mut self, queries: Vec<Vec<u8>>) -> Self {
         self.queries = queries;
         self
     }
@@ -83,8 +83,8 @@ impl<'a> RequestBuilder<'a> {
         let mut request = CoapRequest::new();
         request.set_method(self.method);
         request.set_path(self.path);
-        if let Some(queries) = self.queries {
-            request.message.add_option(CoapOption::UriQuery, queries);
+        for query in self.queries {
+            request.message.add_option(CoapOption::UriQuery, query);
         }
         for (opt, opt_data) in self.options {
             assert_ne!(opt, CoapOption::UriQuery, "Use queries instead");
@@ -119,7 +119,7 @@ pub mod test {
             "/",
             Method::Put,
             Some(b"hello, world!".to_vec()),
-            None,
+            vec![],
             None,
         )
         .build();
@@ -131,7 +131,7 @@ pub mod test {
             "/",
             Method::Put,
             None,
-            None,
+            vec![],
             Some("example.com".to_string()),
         )
         .build();
@@ -151,7 +151,7 @@ pub mod test {
             "/",
             Method::Put,
             None,
-            b"query=hello".to_vec().into(),
+            vec![b"query=hello".to_vec()],
             Some("example.com".to_string()),
         )
         .options(options)


### PR DESCRIPTION
This PR updates the URI decomposition logic to better conform to the CoAP specification ([section 6.4](https://datatracker.ietf.org/doc/html/rfc7252#section-6.4)), addressing the following points:

- **Uri-Host (Point 5)**
  > If the <host> component of |url| does not represent the request's destination IP address as an IP-literal or IPv4address, include a Uri-Host Option [...]

  The implementation now omits the `Uri-Host` option when the `<host>` component is an IP address.

- **Uri-Query (Point 9)**
  > [...] for each argument in the <query> component, include a Uri-Query Option and let that option's value be the argument (not including the question mark and the delimiting ampersand characters) [...]
  
  Query arguments are now correctly split and included as separate `Uri-Query` options. The API for `RequestBuilder` is modified to support this change.