### PR TITLE
Add client-side support for block-wise observe

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -194,4 +194,11 @@ pub mod test {
             .build();
         assert_eq!(build.message.header.get_type(), MessageType::Confirmable);
     }
+    #[test]
+    fn test_non_confirmable_request() {
+        let build = RequestBuilder::new("/", Method::Put)
+            .confirmable(false)
+            .build();
+        assert_eq!(build.message.header.get_type(), MessageType::NonConfirmable);
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -554,6 +554,22 @@ pub mod test {
     }
 
     #[tokio::test]
+    async fn test_listener_instantiation() {
+        let listener = UdpCoapListener::new("127.0.0.1:0").unwrap();
+        assert!(
+            listener.socket.local_addr().unwrap().ip() == IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))
+        );
+        // assert!(listener.socket.blocking() == false);
+
+        let explicit_socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let another_listener = UdpCoapListener::from_socket(explicit_socket);
+        assert!(
+            another_listener.socket.local_addr().unwrap().ip()
+                == IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))
+        );
+    }
+
+    #[tokio::test]
     async fn test_echo_server() {
         let server_port = spawn_server("127.0.0.1:0", request_handler)
             .recv()


### PR DESCRIPTION
Hi, and thanks for maintaining this crate!

I needed client side support for block-wise transfers for observe notifications, so I thought I'd see if you'd be interested in these changes upstream as well. I'm not communicating with a server that's using this crate, so I haven't touched the server side of the code at all. Let me know if you need anything changed!

- Set up synchronized transport before observe registration (to prevent losing first packet).
- Ensure that CoAP messages are populated with tokens.
  - "fixed" token for long-lived receiver in observe loop.
  - new token per block-wise datagram (all blocks in a datagram use the same token)
- Split out blockwise handling to more reusable components.
- Some formatting changes (by `cargo fmt`)
- Basic unit tests of new features