### PR TITLE
[fix] Systematically clear block1 option in block2 requests

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1069,6 +1069,7 @@ impl<T: ClientTransport + 'static> CoAPClient<T> {
 
             if Self::contains_more_blocks(&packet) {
                 // Prepare request for requesting next block
+                request.message.clear_option(CoapOption::Block1);
                 request.message.clear_option(CoapOption::Block2);
                 let mut next_block2 = block2.clone();
                 next_block2.num += 1;


### PR DESCRIPTION
When performing a block-wise transfer combining block1 and block2, the current client implementation let the block1 option set by previous requests when requesting for more block2 chunks. This goes against the specification and may cause error on the server side. In particular, Aiocoap python3 server library triggers an exception when receiving such request. 

Section [2.7](https://datatracker.ietf.org/doc/html/rfc7959#section-2.7) of CoAP RFC7959  specifies :

"[...] To continue this Block2 transfer, the client
   continues to send requests similar to the requests in the Block1
   phase, but leaves out the Block1 Options and includes a Block2
   request option with non-zero NUM."