### PR TITLE
Renamed UdpCoAPClient::new_udp to UdpCoAPClient::new for consistency …

### DIFF
--- a/benches/server.rs
+++ b/benches/server.rs
@@ -38,7 +38,7 @@ fn bench_server_with_request(b: &mut test::Bencher) {
 
     let server_port = rx.blocking_recv().unwrap();
     let client = rt.block_on(async {
-        UdpCoAPClient::new_udp(format!("127.0.0.1:{}", server_port))
+        UdpCoAPClient::new(format!("127.0.0.1:{}", server_port))
             .await
             .unwrap()
     });

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -110,7 +110,7 @@ async fn example_delete() {
 }
 
 async fn example_observe() {
-    let client = UdpCoAPClient::new_udp("127.0.0.1:5683").await.unwrap();
+    let client = UdpCoAPClient::new("127.0.0.1:5683").await.unwrap();
     let observe_channel = client
         .observe("/hello/put", |msg| {
             println!(

--- a/src/client.rs
+++ b/src/client.rs
@@ -390,7 +390,7 @@ impl UdpCoAPClient {
         Self::new_with_tokio_socket(socket, peer_addr).await
     }
 
-    pub async fn new_udp<A: ToSocketAddrs>(addr: A) -> IoResult<Self> {
+    pub async fn new<A: ToSocketAddrs>(addr: A) -> IoResult<Self> {
         let sock_addr = lookup_host(addr).await?.next().ok_or(Error::new(
             ErrorKind::InvalidInput,
             "could not get socket address",
@@ -518,7 +518,7 @@ impl UdpCoAPClient {
     ///
     /// async fn foo() {
     ///   let segment = 0x0;
-    ///   let client = UdpCoAPClient::new_udp("127.0.0.1:5683")
+    ///   let client = UdpCoAPClient::new("127.0.0.1:5683")
     ///          .await
     ///          .unwrap();
     ///   let mut request = RequestBuilder::new("test-echo", RequestType::Get)
@@ -630,7 +630,7 @@ impl<T: ClientTransport + 'static> CoAPClient<T> {
         data: Option<Vec<u8>>,
     ) -> IoResult<CoapResponse> {
         let (domain, port, path, queries) = Self::parse_coap_url(url)?;
-        let client = UdpCoAPClient::new_udp((domain.as_str(), port)).await?;
+        let client = UdpCoAPClient::new((domain.as_str(), port)).await?;
         let request = RequestBuilder::new(&path, method)
             .queries(queries)
             .domain(domain)
@@ -648,7 +648,7 @@ impl<T: ClientTransport + 'static> CoAPClient<T> {
         timeout: Duration,
     ) -> IoResult<CoapResponse> {
         let (domain, port, path, queries) = Self::parse_coap_url(url)?;
-        let mut client = UdpCoAPClient::new_udp((domain.as_str(), port)).await?;
+        let mut client = UdpCoAPClient::new((domain.as_str(), port)).await?;
         client.set_receive_timeout(timeout);
         let request = RequestBuilder::new(&path, method)
             .queries(queries)
@@ -1192,7 +1192,7 @@ mod test {
     #[tokio::test]
     async fn test_get() {
         let domain = "coap.me";
-        let client = UdpCoAPClient::new_udp((domain, 5683)).await.unwrap();
+        let client = UdpCoAPClient::new((domain, 5683)).await.unwrap();
         let resp = client
             .send(
                 RequestBuilder::request_path(
@@ -1223,7 +1223,7 @@ mod test {
     #[tokio::test]
     async fn test_post() {
         let domain = "coap.me";
-        let client = UdpCoAPClient::new_udp((domain, 5683)).await.unwrap();
+        let client = UdpCoAPClient::new((domain, 5683)).await.unwrap();
         let resp = client
             .send(
                 RequestBuilder::request_path(
@@ -1255,7 +1255,7 @@ mod test {
     #[tokio::test]
     async fn test_put() {
         let domain = "coap.me";
-        let client = UdpCoAPClient::new_udp((domain, 5683)).await.unwrap();
+        let client = UdpCoAPClient::new((domain, 5683)).await.unwrap();
         let resp = client
             .send(
                 RequestBuilder::new("/create1", Method::Put)
@@ -1283,7 +1283,7 @@ mod test {
     #[tokio::test]
     async fn test_delete() {
         let domain = "coap.me";
-        let client = UdpCoAPClient::new_udp((domain, 5683)).await.unwrap();
+        let client = UdpCoAPClient::new((domain, 5683)).await.unwrap();
         let resp = client
             .send(
                 RequestBuilder::new("/validate", Method::Delete)
@@ -1297,7 +1297,7 @@ mod test {
 
     #[tokio::test]
     async fn test_set_broadcast() {
-        let client = UdpCoAPClient::new_udp(("127.0.0.1", 5683)).await.unwrap();
+        let client = UdpCoAPClient::new(("127.0.0.1", 5683)).await.unwrap();
         assert!(client.set_broadcast(true).is_ok());
         assert!(client.set_broadcast(false).is_ok());
     }
@@ -1305,7 +1305,7 @@ mod test {
     #[tokio::test]
     #[ignore]
     async fn test_set_broadcast_v6() {
-        let client = UdpCoAPClient::new_udp(("::1", 5683)).await.unwrap();
+        let client = UdpCoAPClient::new(("::1", 5683)).await.unwrap();
         assert!(client.set_broadcast(true).is_ok());
         assert!(client.set_broadcast(false).is_ok());
     }
@@ -1407,7 +1407,7 @@ mod test {
         .await
         .unwrap();
 
-        let mut client = UdpCoAPClient::new_udp(("127.0.0.1", server_port))
+        let mut client = UdpCoAPClient::new(("127.0.0.1", server_port))
             .await
             .unwrap();
         client.set_receive_timeout(Duration::from_secs(1));
@@ -1439,7 +1439,7 @@ mod test {
         .await
         .unwrap();
 
-        let mut client = UdpCoAPClient::new_udp(("127.0.0.1", server_port))
+        let mut client = UdpCoAPClient::new(("127.0.0.1", server_port))
             .await
             .unwrap();
         client.set_transport_retries(1);
@@ -1509,7 +1509,7 @@ mod test {
         .await
         .unwrap();
 
-        let client = UdpCoAPClient::new_udp(("127.0.0.1", server_port))
+        let client = UdpCoAPClient::new(("127.0.0.1", server_port))
             .await
             .unwrap();
 
@@ -1552,7 +1552,7 @@ mod test {
             .set_type(coap_lite::MessageType::NonConfirmable);
         request.message.payload = b"Discovery".to_vec();
 
-        let client = UdpCoAPClient::new_udp(("127.0.0.1", 5683)).await.unwrap();
+        let client = UdpCoAPClient::new(("127.0.0.1", 5683)).await.unwrap();
         client.send_all_coap(&mut request, 0).await.unwrap();
     }
     #[tokio::test]
@@ -1568,7 +1568,7 @@ mod test {
             large_payload.extend_from_slice(PAYLOAD_STR.as_bytes());
         }
         let domain = "coap.me";
-        let mut client = UdpCoAPClient::new_udp((domain, 5683)).await.unwrap();
+        let mut client = UdpCoAPClient::new((domain, 5683)).await.unwrap();
         let resp = client
             .send(
                 RequestBuilder::new("/large-create", Method::Put)
@@ -1606,7 +1606,7 @@ mod test {
             .set_type(coap_lite::MessageType::NonConfirmable);
         request.message.payload = b"Discovery".to_vec();
 
-        let client = UdpCoAPClient::new_udp(("::1", 5683)).await.unwrap();
+        let client = UdpCoAPClient::new(("::1", 5683)).await.unwrap();
         client.send_all_coap(&mut request, 0x4).await.unwrap();
     }
 
@@ -1756,7 +1756,7 @@ mod test {
             .unwrap();
 
         let client = Arc::new(
-            UdpCoAPClient::new_udp(format!("127.0.0.1:{}", server_port))
+            UdpCoAPClient::new(format!("127.0.0.1:{}", server_port))
                 .await
                 .unwrap(),
         );

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -468,7 +468,7 @@ mod test {
 
         let server_address = &format!("127.0.0.1:{}", server_port);
 
-        let client = UdpCoAPClient::new_udp(server_address).await.unwrap();
+        let client = UdpCoAPClient::new(server_address).await.unwrap();
 
         tx.send(step).unwrap();
         let mut request = CoapRequest::new();
@@ -534,7 +534,7 @@ mod test {
 
         let server_address = &format!("127.0.0.1:{}", server_port);
 
-        let client = UdpCoAPClient::new_udp(server_address).await.unwrap();
+        let client = UdpCoAPClient::new(server_address).await.unwrap();
 
         let client3 = client.clone();
 
@@ -567,7 +567,7 @@ mod test {
             .await
             .unwrap();
 
-        let client = UdpCoAPClient::new_udp(format!("127.0.0.1:{}", server_port))
+        let client = UdpCoAPClient::new(format!("127.0.0.1:{}", server_port))
             .await
             .unwrap();
         let error = client.observe(path, |_msg| {}).await.unwrap_err();

--- a/src/server.rs
+++ b/src/server.rs
@@ -435,7 +435,10 @@ impl Server {
             responder.respond(b).await;
         }
     }
-    #[deprecated(since = "0.21.0", note = "Use 'coap::Server::automatic_observe_handling' instead.")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "Use 'coap::Server::automatic_observe_handling' instead."
+    )]
     /// disable auto-observe handling in server
     pub async fn disable_observe_handling(&mut self, value: bool) {
         self.automatic_observe_handling(value).await
@@ -576,7 +579,7 @@ pub mod test {
             .await
             .unwrap();
 
-        let client = UdpCoAPClient::new_udp(format!("127.0.0.1:{}", server_port))
+        let client = UdpCoAPClient::new(format!("127.0.0.1:{}", server_port))
             .await
             .unwrap();
         let mut request = CoapRequest::new();
@@ -610,7 +613,7 @@ pub mod test {
         }
         let payload_size = v.len();
         let server_string = format!("127.0.0.1:{}", server_port);
-        let client = UdpCoAPClient::new_udp(server_string.clone()).await.unwrap();
+        let client = UdpCoAPClient::new(server_string.clone()).await.unwrap();
 
         let request = RequestBuilder::new("/large", RequestType::Put)
             .data(Some(v))
@@ -637,7 +640,7 @@ pub mod test {
     async fn test_echo_server_v6() {
         let server_port = spawn_server("::1:0", request_handler).recv().await.unwrap();
 
-        let client = UdpCoAPClient::new_udp(format!("::1:{}", server_port))
+        let client = UdpCoAPClient::new(format!("::1:{}", server_port))
             .await
             .unwrap();
         let mut request = CoapRequest::new();
@@ -664,7 +667,7 @@ pub mod test {
             .await
             .unwrap();
 
-        let client = UdpCoAPClient::new_udp(format!("127.0.0.1:{}", server_port))
+        let client = UdpCoAPClient::new(format!("127.0.0.1:{}", server_port))
             .await
             .unwrap();
         let mut packet = CoapRequest::new();
@@ -687,7 +690,7 @@ pub mod test {
     async fn test_echo_server_no_token_v6() {
         let server_port = spawn_server("::1:0", request_handler).recv().await.unwrap();
 
-        let client = UdpCoAPClient::new_udp(format!("::1:{}", server_port))
+        let client = UdpCoAPClient::new(format!("::1:{}", server_port))
             .await
             .unwrap();
         let mut packet = CoapRequest::new();
@@ -720,7 +723,7 @@ pub mod test {
             .await
             .unwrap();
 
-        let client = UdpCoAPClient::new_udp(format!("127.0.0.1:{}", server_port))
+        let client = UdpCoAPClient::new(format!("127.0.0.1:{}", server_port))
             .await
             .unwrap();
 
@@ -756,7 +759,7 @@ pub mod test {
         step = 2;
         tx.send(step).unwrap();
         request.message.payload = payload2.clone();
-        let client2 = UdpCoAPClient::new_udp(format!("127.0.0.1:{}", server_port))
+        let client2 = UdpCoAPClient::new(format!("127.0.0.1:{}", server_port))
             .await
             .unwrap();
         let _ = client2.send(request).await.unwrap();
@@ -778,7 +781,7 @@ pub mod test {
             .await
             .unwrap();
 
-        let client = UdpCoAPClient::new_udp(format!("127.0.0.1:{}", server_port))
+        let client = UdpCoAPClient::new(format!("127.0.0.1:{}", server_port))
             .await
             .unwrap();
 
@@ -807,7 +810,7 @@ pub mod test {
             .await
             .unwrap();
 
-        let client = UdpCoAPClient::new_udp(format!("127.0.0.1:{}", server_port))
+        let client = UdpCoAPClient::new(format!("127.0.0.1:{}", server_port))
             .await
             .unwrap();
         let mut request = CoapRequest::new();
@@ -826,7 +829,7 @@ pub mod test {
 
         assert_eq!(recv_packet.message.payload, b"test-echo".to_vec());
 
-        let client = UdpCoAPClient::new_udp(format!("224.0.1.187:{}", server_port))
+        let client = UdpCoAPClient::new(format!("224.0.1.187:{}", server_port))
             .await
             .unwrap();
         let mut request = RequestBuilder::new("test-echo", RequestType::Get)
@@ -853,7 +856,7 @@ pub mod test {
             .await
             .unwrap();
 
-        let client = UdpCoAPClient::new_udp(format!("::1:{}", server_port))
+        let client = UdpCoAPClient::new(format!("::1:{}", server_port))
             .await
             .unwrap();
         let mut request = CoapRequest::new();
@@ -874,7 +877,7 @@ pub mod test {
         assert_eq!(recv_packet.message.payload, b"test-echo".to_vec());
 
         // use 0xff02 to keep it within this network
-        let client = UdpCoAPClient::new_udp(format!("ff0{}::fd:{}", segment, server_port))
+        let client = UdpCoAPClient::new(format!("ff0{}::fd:{}", segment, server_port))
             .await
             .unwrap();
         let mut request = CoapRequest::new();
@@ -978,7 +981,7 @@ pub mod test {
             .await
             .unwrap();
 
-        let client = UdpCoAPClient::new_udp(format!("127.0.0.1:{}", server_port))
+        let client = UdpCoAPClient::new(format!("127.0.0.1:{}", server_port))
             .await
             .unwrap();
         let resp = client


### PR DESCRIPTION
Proposing to rename `UdpCoAPClient::new_udp` to `UdpCoAPClient::new` for consistency with `CoAPClient`.
Specifying `udp` is not needed, as it is contained in the struct name.