### PR TITLE
Add block-wise observe support for large resources

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -989,7 +989,7 @@ impl<T: ClientTransport + 'static> CoAPClient<T> {
     /// Returns `std::io::Error` with `ErrorKind::InvalidData` if the message contains
     /// an ETag mismatch. This indicates the resource changed during the block transfer,
     /// and the client MUST abort the current transfer and wait for the next notification.
-    /// Users should check `e.to_string().contains("ETag mismatch")` to handle this gracefully.
+    /// Callers should branch on `e.kind() == ErrorKind::InvalidData` to handle this gracefully.
     async fn receive_with_etag_validation(
         &self,
         request: &mut CoapRequest<SocketAddr>,
@@ -1007,6 +1007,11 @@ impl<T: ClientTransport + 'static> CoAPClient<T> {
                         .unwrap_or(false);
 
                     if !etag_matches {
+                        debug!(
+                            "ETag mismatch detected: expected {:?}, got {:?}. Aborting block transfer.",
+                            expected,
+                            response.message.get_option(CoapOption::ETag)
+                        );
                         return Err(Error::new(
                             ErrorKind::InvalidData,
                             "ETag mismatch: resource changed during block transfer",

--- a/src/client.rs
+++ b/src/client.rs
@@ -42,6 +42,11 @@ pub struct Packet {
 }
 
 #[derive(Debug)]
+/// Represents control messages for an observation relationship.
+///
+/// Note: Cancellation via `Terminate` is inherently best-effort over UDP.
+/// If the deregistration message is lost, the server may continue sending notifications.
+/// Client code should be prepared to ignore unexpected messages after calling `send(Terminate)`.
 pub enum ObserveMessage {
     Terminate,
 }
@@ -834,8 +839,11 @@ impl<T: ClientTransport + 'static> CoAPClient<T> {
             Ok(response) => {
                 if let Some(block2) = CoAPClient::<T>::get_block2_option(&response.message) {
                     if CoAPClient::<T>::contains_more_blocks(&response.message) {
-                        // Start of a new blockwise transfer.
-                        // Receive the rest before passing it on to the user-defined handler.
+                        let expected_etag: Option<Vec<u8>> = response
+                            .message
+                            .get_option(CoapOption::ETag)
+                            .and_then(|iter| iter.front().cloned());
+
                         request.response = Some(CoapResponse {
                             message: response.message.clone(),
                         });
@@ -853,19 +861,17 @@ impl<T: ClientTransport + 'static> CoAPClient<T> {
                             .message
                             .add_option_as::<BlockValue>(CoapOption::Block2, next_block2);
 
-                        let full_datagram = self.receive(request).await;
-                        // Pass the message on to the user-defined handler
+                        let full_datagram = self
+                            .receive_with_etag_validation(request, expected_etag.as_deref())
+                            .await;
+
                         if let Ok(full_datagram) = full_datagram {
                             handler(full_datagram.message.clone());
                         }
                     } else {
-                        // A full datagram has been received
-                        // Pass the message on to the user-defined handler
                         handler(response.message);
                     }
                 } else {
-                    // A full datagram has been received
-                    // Pass the message on to the user-defined handler
                     handler(response.message);
                 }
             }
@@ -958,6 +964,57 @@ impl<T: ClientTransport + 'static> CoAPClient<T> {
     async fn receive(&self, request: &mut CoapRequest<SocketAddr>) -> IoResult<CoapResponse> {
         let mut block2_state = BlockState::default();
         loop {
+            match Self::intercept_response(request, &mut block2_state) {
+                Ok(true) => {
+                    request.message.header.message_id = self.gen_message_id();
+                    let resp = self.send_single_request(request).await?;
+                    request.response = Some(resp);
+                }
+                Err(err) => {
+                    error!("intercept response error: {:?}", err);
+                    return Err(Error::new(ErrorKind::Interrupted, "packet error"));
+                }
+                Ok(false) => {
+                    break;
+                }
+            }
+        }
+        Ok(CoapResponse {
+            message: request.response.as_ref().unwrap().message.clone(),
+        })
+    }
+
+    /// Receive a response supporting block-wise with ETag validation.
+    ///
+    /// Returns `std::io::Error` with `ErrorKind::InvalidData` if the message contains
+    /// an ETag mismatch. This indicates the resource changed during the block transfer,
+    /// and the client MUST abort the current transfer and wait for the next notification.
+    /// Users should check `e.to_string().contains("ETag mismatch")` to handle this gracefully.
+    async fn receive_with_etag_validation(
+        &self,
+        request: &mut CoapRequest<SocketAddr>,
+        expected_etag: Option<&[u8]>,
+    ) -> IoResult<CoapResponse> {
+        let mut block2_state = BlockState::default();
+        loop {
+            if let Some(expected) = expected_etag {
+                if let Some(ref response) = request.response {
+                    let etag_matches = response
+                        .message
+                        .get_option(CoapOption::ETag)
+                        .and_then(|iter| iter.front())
+                        .map(|etag: &Vec<u8>| etag.as_slice() == expected)
+                        .unwrap_or(false);
+
+                    if !etag_matches {
+                        return Err(Error::new(
+                            ErrorKind::InvalidData,
+                            "ETag mismatch: resource changed during block transfer",
+                        ));
+                    }
+                }
+            }
+
             match Self::intercept_response(request, &mut block2_state) {
                 Ok(true) => {
                     request.message.header.message_id = self.gen_message_id();
@@ -1856,5 +1913,198 @@ mod test {
                 .is_err(),
             "failed transport should make all other requests fail"
         )
+    }
+
+    fn generate_large_payload(byte: u8) -> Vec<u8> {
+        let payload = vec![byte; 2048];
+        assert!(
+            payload.len() > 1024,
+            "Test payload must be larger than default block size"
+        );
+        payload
+    }
+
+    async fn large_resource_handler(
+        mut req: Box<CoapRequest<SocketAddr>>,
+    ) -> Box<CoapRequest<SocketAddr>> {
+        if req.response.is_none() {
+            req.response = Some(CoapResponse {
+                message: Message::new(),
+            });
+        }
+
+        if let Some(ref mut response) = req.response {
+            response.message.payload = b"OK".to_vec();
+        }
+        req
+    }
+
+    #[tokio::test]
+    async fn test_observe_large_resource_continuous_update() {
+        let server_port = server::test::spawn_server("127.0.0.1:0", large_resource_handler)
+            .recv()
+            .await
+            .unwrap();
+        let addr = format!("127.0.0.1:{}", server_port);
+        let client = UdpCoAPClient::new(&addr).await.unwrap();
+
+        let payload_a = generate_large_payload(b'a');
+        let put_req = RequestBuilder::new("/large", Method::Put)
+            .data(Some(payload_a.clone()))
+            .build();
+        client.send(put_req).await.unwrap();
+
+        let received_payloads = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let received_payloads_clone = received_payloads.clone();
+
+        let mut observe_req = CoapRequest::new();
+        observe_req.set_method(Method::Get);
+        observe_req.set_path("/large");
+        observe_req.message.add_option_as::<BlockValue>(
+            CoapOption::Block2,
+            BlockValue::new(0, false, 1024).unwrap(),
+        );
+
+        let unsubscriber = client
+            .observe_with(observe_req, move |msg| {
+                let mut lock = received_payloads_clone.lock().unwrap();
+                lock.push(msg.payload.clone());
+            })
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let first_payloads = received_payloads.lock().unwrap().clone();
+        assert_eq!(
+            first_payloads.len(),
+            1,
+            "Should receive initial notification"
+        );
+        assert_eq!(first_payloads[0], payload_a, "Initial payload mismatch");
+
+        let payload_b = generate_large_payload(b'b');
+        let put_req2 = RequestBuilder::new("/large", Method::Put)
+            .data(Some(payload_b.clone()))
+            .build();
+        client.send(put_req2).await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let second_payloads = received_payloads.lock().unwrap().clone();
+        assert_eq!(
+            second_payloads.len(),
+            2,
+            "Should receive update notification"
+        );
+        assert_eq!(second_payloads[1], payload_b, "Updated payload mismatch");
+
+        let _ = unsubscriber.send(ObserveMessage::Terminate);
+    }
+
+    #[tokio::test]
+    async fn test_observe_cancel_stops_future_notifications() {
+        let server_port = server::test::spawn_server("127.0.0.1:0", large_resource_handler)
+            .recv()
+            .await
+            .unwrap();
+        let addr = format!("127.0.0.1:{}", server_port);
+        let client = UdpCoAPClient::new(&addr).await.unwrap();
+
+        // Use small payload to avoid exceeding client's 1500 byte UDP receive buffer
+        let payload_a = vec![b'a'; 100];
+        client
+            .send(
+                RequestBuilder::new("/large", Method::Put)
+                    .data(Some(payload_a.clone()))
+                    .build(),
+            )
+            .await
+            .unwrap();
+
+        let handler_counter = Arc::new(AtomicU16::new(0));
+        let handler_counter_clone = handler_counter.clone();
+
+        let unsubscriber = client
+            .observe("/large", move |_msg| {
+                handler_counter_clone.fetch_add(1, Ordering::Relaxed);
+            })
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        assert_eq!(
+            handler_counter.load(Ordering::Relaxed),
+            1,
+            "Initial observe failed"
+        );
+
+        let _ = unsubscriber.send(ObserveMessage::Terminate);
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let payload_b = vec![b'b'; 100];
+        client
+            .send(
+                RequestBuilder::new("/large", Method::Put)
+                    .data(Some(payload_b))
+                    .build(),
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        assert_eq!(
+            handler_counter.load(Ordering::Relaxed),
+            1,
+            "Should not receive notification after cancel"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_observe_large_resource_no_block2_fallback() {
+        let server_port = server::test::spawn_server("127.0.0.1:0", large_resource_handler)
+            .recv()
+            .await
+            .unwrap();
+        let addr = format!("127.0.0.1:{}", server_port);
+        let client = UdpCoAPClient::new(&addr).await.unwrap();
+
+        // Use 1200 bytes: larger than 1024 block size, but smaller than 1500 UDP buffer limit
+        let payload = vec![b'x'; 1200];
+        client
+            .send(
+                RequestBuilder::new("/large", Method::Put)
+                    .data(Some(payload.clone()))
+                    .build(),
+            )
+            .await
+            .unwrap();
+
+        let handler_received_full = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let handler_received_full_clone = handler_received_full.clone();
+
+        // Construct registration request without Block2 option
+        let mut req = CoapRequest::new();
+        req.set_method(Method::Get);
+        req.set_path("/large");
+
+        let unsubscriber = client
+            .observe_with(req, move |msg| {
+                // Verify that even without Block2 and larger than default block size, full data is received at once
+                assert_eq!(msg.payload.len(), 1200);
+                assert_eq!(msg.payload, payload);
+                handler_received_full_clone.store(true, Ordering::Relaxed);
+            })
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        assert!(
+            handler_received_full.load(Ordering::Relaxed),
+            "Fallback to full payload failed"
+        );
+
+        let _ = unsubscriber.send(ObserveMessage::Terminate);
     }
 }

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -352,13 +352,25 @@ impl Observer {
 
         self.register_resources
             .entry(register_resource_key.clone())
-            .or_insert(RegisterResourceItem {
+            .and_modify(|existing| {
+                // Clear any pending unacknowledged message to prevent stale timeout logic
+                if let Some(old_msg_id) = existing.unacknowledge_message.take() {
+                    self.unacknowledge_messages.remove(&old_msg_id);
+                }
+
+                // Refresh the observation state with new parameters
+                existing.registered_responder = register_key.clone();
+                existing.token = token.into();
+                existing.preferred_block_size = preferred_block_size;
+            })
+            .or_insert_with(|| RegisterResourceItem {
                 registered_responder: register_key.clone(),
                 resource: path.clone(),
                 token: token.into(),
                 unacknowledge_message: None,
                 preferred_block_size,
             });
+
         resource
             .register_resources
             .replace(register_resource_key.clone());
@@ -1061,5 +1073,95 @@ mod test {
         );
         let size2_val = decode_uint(size2_opt.unwrap());
         assert_eq!(size2_val, 0, "Size2 value should be 0 for empty payload");
+    }
+
+    #[tokio::test]
+    async fn test_observe_reregistration_updates_token_and_block_size() {
+        let mut observer = Observer::new();
+        let path = "test_update";
+        let addr: SocketAddr = "127.0.0.1:6001".parse().unwrap();
+
+        // Create a resource larger than block sizes to trigger block-wise transfer
+        let payload = vec![0xAA; 1500];
+        let mut put_req = CoapRequest::<SocketAddr>::new();
+        put_req.set_method(Method::Put);
+        put_req.set_path(path);
+        put_req.message.payload = payload.clone();
+        put_req.source = Some(addr);
+        observer
+            .request_handler(&mut put_req, Arc::new(MockResponder::new(addr)))
+            .await;
+
+        // Initial registration with Token A and Block2 preference 1024
+        let mut reg_req1 = CoapRequest::<SocketAddr>::new();
+        reg_req1.set_method(Method::Get);
+        reg_req1.set_path(path);
+        reg_req1.set_observe_flag(ObserveOption::Register);
+        reg_req1.message.set_token(vec![1]); // Token A
+        reg_req1.message.add_option_as::<BlockValue>(
+            CoapOption::Block2,
+            BlockValue::new(0, false, 1024).unwrap(),
+        );
+        reg_req1.source = Some(addr);
+        reg_req1.response = Some(CoapResponse {
+            message: Packet::new(),
+        });
+
+        let responder1 = Arc::new(MockResponder::new(addr));
+        observer
+            .request_handler(&mut reg_req1, responder1.clone())
+            .await;
+
+        // Re-registration from the same client with Token B and Block2 preference 512
+        let mut reg_req2 = CoapRequest::<SocketAddr>::new();
+        reg_req2.set_method(Method::Get);
+        reg_req2.set_path(path);
+        reg_req2.set_observe_flag(ObserveOption::Register);
+        reg_req2.message.set_token(vec![2]); // Token B
+        reg_req2.message.add_option_as::<BlockValue>(
+            CoapOption::Block2,
+            BlockValue::new(0, false, 512).unwrap(), // New preference
+        );
+        reg_req2.source = Some(addr);
+        reg_req2.response = Some(CoapResponse {
+            message: Packet::new(),
+        });
+
+        let responder2 = Arc::new(MockResponder::new(addr));
+        observer
+            .request_handler(&mut reg_req2, responder2.clone())
+            .await;
+
+        // Trigger a resource change to force a notification
+        let mut put_req2 = CoapRequest::<SocketAddr>::new();
+        put_req2.set_method(Method::Put);
+        put_req2.set_path(path);
+        put_req2.message.payload = vec![0xBB; 1500];
+        put_req2.source = Some(addr);
+        observer
+            .request_handler(&mut put_req2, responder2.clone())
+            .await;
+
+        // Fetch the notification sent by the observer
+        let resp_bytes = responder2.get_last_sent().await.unwrap();
+        let resp_pkt = Packet::from_bytes(&resp_bytes).unwrap();
+
+        // Verify the server used the updated state (Token B and Block size 512)
+        assert_eq!(
+            resp_pkt.get_token(),
+            vec![2],
+            "Server should use the updated token from re-registration"
+        );
+        assert_eq!(
+            resp_pkt.payload.len(),
+            512,
+            "Server should use the updated block size preference from re-registration"
+        );
+
+        let block2_opt = resp_pkt
+            .get_first_option_as::<BlockValue>(CoapOption::Block2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(block2_opt.size(), 512);
     }
 }

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -1,6 +1,6 @@
 use coap_lite::{
-    CoapRequest, MessageClass, MessageType, ObserveOption, Packet, RequestType as Method,
-    ResponseType as Status,
+    block_handler::BlockValue, CoapOption, CoapRequest, MessageClass, MessageType, ObserveOption,
+    Packet, RequestType as Method, ResponseType as Status,
 };
 use futures::{
     stream::{Fuse, SelectNextSome},
@@ -36,9 +36,10 @@ struct RegisterItem {
 
 #[derive(Debug)]
 struct ResourceItem {
-    payload: Vec<u8>,
+    payload: Arc<Vec<u8>>,
     register_resources: HashSet<String>,
     sequence: u32,
+    etag: Vec<u8>,
 }
 
 struct RegisterResourceItem {
@@ -46,6 +47,7 @@ struct RegisterResourceItem {
     pub(crate) resource: String,
     pub(crate) token: Vec<u8>,
     pub(crate) unacknowledge_message: Option<u16>,
+    pub(crate) preferred_block_size: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -68,8 +70,33 @@ impl Observer {
     }
 
     /// poll the observer's timer.
-    pub fn select_next_some(&mut self) -> SelectNextSome<Fuse<IntervalStream>> {
+    pub fn select_next_some(&mut self) -> SelectNextSome<'_, Fuse<IntervalStream>> {
         self.timer.select_next_some()
+    }
+
+    /// Checks if the given client endpoint is currently observing the specified resource.
+    pub fn is_observing(&self, addr: &SocketAddr, path: &String) -> bool {
+        let key = Self::format_register_resource(addr, path);
+        self.register_resources.contains_key(&key)
+    }
+
+    /// Returns a shared reference to the resource payload and its current ETag.
+    /// Used by the server to serve remaining blocks consistently during a block-wise transfer.
+    pub fn get_resource_payload_and_etag(&self, path: &String) -> Option<(Arc<Vec<u8>>, Vec<u8>)> {
+        self.resources
+            .get(path)
+            .map(|r| (r.payload.clone(), r.etag.clone()))
+    }
+
+    /// Computes a non-cryptographic ETag using FNV-1a hash for change detection only.
+    /// This ETag is not suitable for security purposes (e.g., integrity validation against attackers).
+    fn compute_etag(payload: &[u8]) -> Vec<u8> {
+        let mut hash: u64 = 0xcbf29ce484222325;
+        for &byte in payload {
+            hash ^= byte as u64;
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        hash.to_be_bytes()[..4].to_vec()
     }
 
     /// filter the requests belong to the observer. store the responder in case it is needed
@@ -153,22 +180,46 @@ impl Observer {
             return;
         }
 
+        let preferred_block_size = request
+            .message
+            .get_first_option_as::<BlockValue>(CoapOption::Block2)
+            .and_then(|x: Result<BlockValue, _>| x.ok())
+            .map(|b: BlockValue| b.size());
+
         self.record_register_resource(
             responder.clone(),
             &resource_path,
             &request.message.get_token(),
+            preferred_block_size,
         );
 
         let resource = self.resources.get(&resource_path).unwrap();
 
         if let Some(response) = request.response.take() {
             let mut response2 = response.clone();
-            response2.message.payload = resource.payload.clone();
             response2.message.set_observe_value(resource.sequence);
             response2
                 .message
                 .header
                 .set_type(MessageType::NonConfirmable);
+            response2
+                .message
+                .add_option(CoapOption::ETag, resource.etag.clone());
+
+            if let Some(block_size) = preferred_block_size {
+                if resource.payload.len() > block_size {
+                    let block = BlockValue::new(0, true, block_size).expect("valid block size");
+                    response2
+                        .message
+                        .add_option_as::<BlockValue>(CoapOption::Block2, block);
+                    response2.message.payload = resource.payload[..block_size].to_vec();
+                } else {
+                    response2.message.payload = resource.payload.to_vec();
+                }
+            } else {
+                response2.message.payload = resource.payload.to_vec();
+            }
+
             if let Ok(b) = response2.message.to_bytes() {
                 responder.respond(b).await;
             }
@@ -276,6 +327,7 @@ impl Observer {
         responder: Arc<dyn Responder>,
         path: &String,
         token: &[u8],
+        preferred_block_size: Option<usize>,
     ) {
         let resource = self.resources.get_mut(path).unwrap();
         let register_key = responder;
@@ -289,6 +341,7 @@ impl Observer {
                 resource: path.clone(),
                 token: token.into(),
                 unacknowledge_message: None,
+                preferred_block_size,
             });
         resource
             .register_resources
@@ -367,16 +420,16 @@ impl Observer {
             Entry::Occupied(resource) => {
                 let r = resource.into_mut();
                 r.sequence += 1;
-                r.payload = payload.clone();
-                return r;
+                r.payload = Arc::new(payload.clone());
+                r.etag = Self::compute_etag(payload);
+                r
             }
-            Entry::Vacant(v) => {
-                return v.insert(ResourceItem {
-                    payload: payload.clone(),
-                    register_resources: HashSet::new(),
-                    sequence: 0,
-                });
-            }
+            Entry::Vacant(v) => v.insert(ResourceItem {
+                payload: Arc::new(payload.clone()),
+                register_resources: HashSet::new(),
+                sequence: 0,
+                etag: Self::compute_etag(payload),
+            }),
         }
     }
 
@@ -448,6 +501,15 @@ impl Observer {
         self.unacknowledge_messages.remove(message_id);
     }
 
+    /// Notifies a specific registered observer about a resource change.
+    ///
+    /// Note on Architecture: The payload truncation and Block2 option injection for the
+    /// first block are handled directly within `Observer` rather than the generic
+    /// `intercept_response` in `server.rs`. This is a deliberate design choice to maintain
+    /// single-responsibility in a push-based context: asynchronous notifications bypass the
+    /// main server request/response loop and are sent directly via the `Responder`.
+    /// Centralizing the "first block generation" logic here avoids duplicating the truncation
+    /// code for both synchronous registrations and asynchronous notifications.
     async fn notify_register_with_newest_resource(&mut self, register_resource_key: &String) {
         let message_id = self.current_message_id;
 
@@ -463,7 +525,20 @@ impl Observer {
         message.set_token(register_resource.token.clone());
         message.set_observe_value(resource.sequence);
         message.header.message_id = message_id;
-        message.payload = resource.payload.clone();
+        message.add_option(CoapOption::ETag, resource.etag.clone());
+
+        if let Some(block_size) = register_resource.preferred_block_size {
+            if resource.payload.len() > block_size {
+                let block = BlockValue::new(0, true, block_size).expect("valid block size");
+                message.add_option_as::<BlockValue>(CoapOption::Block2, block);
+                message.payload = resource.payload[..block_size].to_vec();
+            } else {
+                message.payload = resource.payload.to_vec();
+            }
+        } else {
+            message.payload = resource.payload.to_vec();
+        }
+
         if let Ok(b) = message.to_bytes() {
             debug!("notify register with newest resource {:?}", &b);
             register_resource.registered_responder.respond(b).await;
@@ -487,6 +562,8 @@ mod test {
 
     use super::super::*;
     use super::*;
+    use async_trait::async_trait;
+    use coap_lite::CoapResponse;
     use std::io::ErrorKind;
     use tokio::sync::mpsc;
 
@@ -662,9 +739,10 @@ mod test {
         observer.resources.insert(
             path.to_string(),
             ResourceItem {
-                payload: vec![],
+                payload: Arc::new(vec![]),
                 register_resources: HashSet::new(),
                 sequence: 0,
+                etag: vec![],
             },
         );
 
@@ -734,5 +812,147 @@ mod test {
             result.is_err(),
             "Expected no notification after RST cancellation"
         );
+    }
+
+    use tokio::sync::Mutex;
+
+    struct MockResponder {
+        addr: SocketAddr,
+        last_sent: Arc<Mutex<Option<Vec<u8>>>>,
+    }
+
+    impl MockResponder {
+        fn new(addr: SocketAddr) -> Self {
+            Self {
+                addr,
+                last_sent: Arc::new(Mutex::new(None)),
+            }
+        }
+
+        async fn get_last_sent(&self) -> Option<Vec<u8>> {
+            self.last_sent.lock().await.clone()
+        }
+    }
+
+    #[async_trait]
+    impl Responder for MockResponder {
+        async fn respond(&self, bytes: Vec<u8>) {
+            *self.last_sent.lock().await = Some(bytes);
+        }
+        fn address(&self) -> SocketAddr {
+            self.addr
+        }
+    }
+
+    #[tokio::test]
+    async fn test_observer_block_size_boundaries_and_preferences() {
+        let mut observer = Observer::new();
+        let path = "test";
+        let addr1: SocketAddr = "127.0.0.1:5001".parse().unwrap();
+        let addr2: SocketAddr = "127.0.0.1:5002".parse().unwrap();
+
+        // 1. Prepare a resource exactly equal to block_size (1024 bytes)
+        let payload_exact = vec![0xAA; 1024];
+        let mut put_req = CoapRequest::<SocketAddr>::new();
+        put_req.set_method(Method::Put); // Must be set to PUT
+        put_req.set_path(path);
+        put_req.message.payload = payload_exact.clone();
+        put_req.source = Some(addr1);
+        observer
+            .request_handler(&mut put_req, Arc::new(MockResponder::new(addr1)))
+            .await;
+
+        // 2. Simulate Client 1 registering, expecting block size 1024
+        let mut reg_req1 = CoapRequest::<SocketAddr>::new();
+        reg_req1.set_method(Method::Get);
+        reg_req1.set_path(path);
+        reg_req1.set_observe_flag(ObserveOption::Register); // Must set Observe flag
+        reg_req1.message.add_option_as::<BlockValue>(
+            CoapOption::Block2,
+            BlockValue::new(0, false, 1024).unwrap(),
+        );
+        reg_req1.source = Some(addr1);
+        reg_req1.response = Some(CoapResponse {
+            message: Packet::new(),
+        }); // Must initialize response
+
+        let responder1 = Arc::new(MockResponder::new(addr1));
+        observer
+            .request_handler(&mut reg_req1, responder1.clone())
+            .await;
+
+        let resp1_bytes = responder1.get_last_sent().await.unwrap();
+        let resp1_pkt = Packet::from_bytes(&resp1_bytes).unwrap();
+
+        // Assertion: payload equals block size, server should not add Block2
+        assert_eq!(resp1_pkt.payload.len(), 1024);
+        assert!(
+            resp1_pkt.get_option(CoapOption::Block2).is_none(),
+            "Should not add Block2 if exactly equal"
+        );
+
+        // 3. Prepare a resource larger than block_size (1500 bytes)
+        let payload_large = vec![0xBB; 1500];
+        let mut put_req2 = CoapRequest::<SocketAddr>::new();
+        put_req2.set_method(Method::Put);
+        put_req2.set_path(path);
+        put_req2.message.payload = payload_large.clone();
+        put_req2.source = Some(addr1);
+        observer
+            .request_handler(&mut put_req2, Arc::new(MockResponder::new(addr1)))
+            .await;
+
+        // 4. Simulate Client 2 registering, expecting smaller block size (512 bytes)
+        let mut reg_req2 = CoapRequest::<SocketAddr>::new();
+        reg_req2.set_method(Method::Get);
+        reg_req2.set_path(path);
+        reg_req2.set_observe_flag(ObserveOption::Register);
+        reg_req2.message.add_option_as::<BlockValue>(
+            CoapOption::Block2,
+            BlockValue::new(0, false, 512).unwrap(),
+        );
+        reg_req2.message.set_token(vec![2]);
+        reg_req2.source = Some(addr2);
+        reg_req2.response = Some(CoapResponse {
+            message: Packet::new(),
+        }); // Must initialize response
+
+        let responder2 = Arc::new(MockResponder::new(addr2));
+        observer
+            .request_handler(&mut reg_req2, responder2.clone())
+            .await;
+
+        let resp2_bytes = responder2.get_last_sent().await.unwrap();
+        let resp2_pkt = Packet::from_bytes(&resp2_bytes).unwrap();
+
+        // Assertion: Client 2 receives first block, size matches its 512 preference
+        assert_eq!(resp2_pkt.payload.len(), 512);
+        let block2_opt = resp2_pkt
+            .get_first_option_as::<BlockValue>(CoapOption::Block2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(block2_opt.size(), 512);
+        assert!(block2_opt.more, "Should have more blocks");
+
+        // 5. Verify Client 1's preference (1024) was not overwritten by Client 2 (512)
+        let mut put_req3 = CoapRequest::<SocketAddr>::new();
+        put_req3.set_method(Method::Put);
+        put_req3.set_path(path);
+        put_req3.message.payload = vec![0xCC; 1500];
+        put_req3.source = Some(addr1);
+        observer
+            .request_handler(&mut put_req3, responder1.clone())
+            .await;
+
+        let resp1_notify_bytes = responder1.get_last_sent().await.unwrap();
+        let resp1_notify_pkt = Packet::from_bytes(&resp1_notify_bytes).unwrap();
+
+        // Assertion: Client 1's notification is still a 1024 byte block
+        assert_eq!(resp1_notify_pkt.payload.len(), 1024);
+        let notify_block2 = resp1_notify_pkt
+            .get_first_option_as::<BlockValue>(CoapOption::Block2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(notify_block2.size(), 1024);
     }
 }

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -56,6 +56,17 @@ struct UnacknowledgeMessageItem {
     try_times: usize,
 }
 
+/// Encodes a usize as a CoAP uint (big-endian, variable length up to 4 bytes).
+/// The value 0 is encoded as an empty byte slice. Values larger than 2^32-1 are saturated.
+pub(crate) fn encode_coap_uint(value: usize) -> Vec<u8> {
+    (value.min(u32::MAX as usize) as u32)
+        .to_be_bytes()
+        .iter()
+        .skip_while(|&&b| b == 0)
+        .copied()
+        .collect()
+}
+
 impl Observer {
     /// Creates an observer with channel to send message.
     pub fn new() -> Self {
@@ -205,6 +216,11 @@ impl Observer {
             response2
                 .message
                 .add_option(CoapOption::ETag, resource.etag.clone());
+
+            let total_size = resource.payload.len();
+            response2
+                .message
+                .add_option(CoapOption::Size2, encode_coap_uint(total_size));
 
             if let Some(block_size) = preferred_block_size {
                 if resource.payload.len() > block_size {
@@ -527,6 +543,9 @@ impl Observer {
         message.header.message_id = message_id;
         message.add_option(CoapOption::ETag, resource.etag.clone());
 
+        let total_size = resource.payload.len();
+        message.add_option(CoapOption::Size2, encode_coap_uint(total_size));
+
         if let Some(block_size) = register_resource.preferred_block_size {
             if resource.payload.len() > block_size {
                 let block = BlockValue::new(0, true, block_size).expect("valid block size");
@@ -586,6 +605,10 @@ mod test {
             _ => {}
         };
         return req;
+    }
+
+    fn decode_uint(data: &[u8]) -> usize {
+        data.iter().fold(0, |acc, &b| (acc << 8) | b as usize)
     }
 
     #[tokio::test]
@@ -854,7 +877,7 @@ mod test {
         // 1. Prepare a resource exactly equal to block_size (1024 bytes)
         let payload_exact = vec![0xAA; 1024];
         let mut put_req = CoapRequest::<SocketAddr>::new();
-        put_req.set_method(Method::Put); // Must be set to PUT
+        put_req.set_method(Method::Put);
         put_req.set_path(path);
         put_req.message.payload = payload_exact.clone();
         put_req.source = Some(addr1);
@@ -862,11 +885,11 @@ mod test {
             .request_handler(&mut put_req, Arc::new(MockResponder::new(addr1)))
             .await;
 
-        // 2. Simulate Client 1 registering, expecting block size 1024
+        // 2. Client 1 registers, expecting block size 1024
         let mut reg_req1 = CoapRequest::<SocketAddr>::new();
         reg_req1.set_method(Method::Get);
         reg_req1.set_path(path);
-        reg_req1.set_observe_flag(ObserveOption::Register); // Must set Observe flag
+        reg_req1.set_observe_flag(ObserveOption::Register);
         reg_req1.message.add_option_as::<BlockValue>(
             CoapOption::Block2,
             BlockValue::new(0, false, 1024).unwrap(),
@@ -874,7 +897,7 @@ mod test {
         reg_req1.source = Some(addr1);
         reg_req1.response = Some(CoapResponse {
             message: Packet::new(),
-        }); // Must initialize response
+        });
 
         let responder1 = Arc::new(MockResponder::new(addr1));
         observer
@@ -884,14 +907,22 @@ mod test {
         let resp1_bytes = responder1.get_last_sent().await.unwrap();
         let resp1_pkt = Packet::from_bytes(&resp1_bytes).unwrap();
 
-        // Assertion: payload equals block size, server should not add Block2
         assert_eq!(resp1_pkt.payload.len(), 1024);
         assert!(
             resp1_pkt.get_option(CoapOption::Block2).is_none(),
             "Should not add Block2 if exactly equal"
         );
 
-        // 3. Prepare a resource larger than block_size (1500 bytes)
+        // Size2 assertion for Client 1 registration
+        let size2_opt = resp1_pkt.get_first_option(CoapOption::Size2);
+        assert!(
+            size2_opt.is_some(),
+            "Size2 missing in register response (no block2)"
+        );
+        let size2_val = decode_uint(size2_opt.unwrap());
+        assert_eq!(size2_val, 1024, "Size2 value mismatch");
+
+        // 3. Prepare larger resource (1500 bytes)
         let payload_large = vec![0xBB; 1500];
         let mut put_req2 = CoapRequest::<SocketAddr>::new();
         put_req2.set_method(Method::Put);
@@ -902,7 +933,7 @@ mod test {
             .request_handler(&mut put_req2, Arc::new(MockResponder::new(addr1)))
             .await;
 
-        // 4. Simulate Client 2 registering, expecting smaller block size (512 bytes)
+        // 4. Client 2 registers, expecting block size 512
         let mut reg_req2 = CoapRequest::<SocketAddr>::new();
         reg_req2.set_method(Method::Get);
         reg_req2.set_path(path);
@@ -915,7 +946,7 @@ mod test {
         reg_req2.source = Some(addr2);
         reg_req2.response = Some(CoapResponse {
             message: Packet::new(),
-        }); // Must initialize response
+        });
 
         let responder2 = Arc::new(MockResponder::new(addr2));
         observer
@@ -925,7 +956,6 @@ mod test {
         let resp2_bytes = responder2.get_last_sent().await.unwrap();
         let resp2_pkt = Packet::from_bytes(&resp2_bytes).unwrap();
 
-        // Assertion: Client 2 receives first block, size matches its 512 preference
         assert_eq!(resp2_pkt.payload.len(), 512);
         let block2_opt = resp2_pkt
             .get_first_option_as::<BlockValue>(CoapOption::Block2)
@@ -934,7 +964,19 @@ mod test {
         assert_eq!(block2_opt.size(), 512);
         assert!(block2_opt.more, "Should have more blocks");
 
-        // 5. Verify Client 1's preference (1024) was not overwritten by Client 2 (512)
+        // Size2 assertion for Client 2 registration
+        let size2_opt2 = resp2_pkt.get_first_option(CoapOption::Size2);
+        assert!(
+            size2_opt2.is_some(),
+            "Size2 missing in register response with block2"
+        );
+        let size2_val2 = decode_uint(size2_opt2.unwrap());
+        assert_eq!(
+            size2_val2, 1500,
+            "Size2 value mismatch in block2 registration"
+        );
+
+        // 5. Trigger a resource change (PUT) to cause notification to Client 1
         let mut put_req3 = CoapRequest::<SocketAddr>::new();
         put_req3.set_method(Method::Put);
         put_req3.set_path(path);
@@ -947,12 +989,77 @@ mod test {
         let resp1_notify_bytes = responder1.get_last_sent().await.unwrap();
         let resp1_notify_pkt = Packet::from_bytes(&resp1_notify_bytes).unwrap();
 
-        // Assertion: Client 1's notification is still a 1024 byte block
         assert_eq!(resp1_notify_pkt.payload.len(), 1024);
         let notify_block2 = resp1_notify_pkt
             .get_first_option_as::<BlockValue>(CoapOption::Block2)
             .unwrap()
             .unwrap();
         assert_eq!(notify_block2.size(), 1024);
+
+        // Size2 assertion for notification
+        let size2_opt_notify = resp1_notify_pkt.get_first_option(CoapOption::Size2);
+        assert!(size2_opt_notify.is_some(), "Size2 missing in notification");
+        let size2_val_notify = decode_uint(size2_opt_notify.unwrap());
+        assert_eq!(
+            size2_val_notify, 1500,
+            "Size2 value mismatch in notification"
+        );
+    }
+
+    #[test]
+    fn test_encode_coap_uint() {
+        assert_eq!(encode_coap_uint(0), vec![]);
+        assert_eq!(encode_coap_uint(1), vec![0x01]);
+        assert_eq!(encode_coap_uint(255), vec![0xFF]);
+        assert_eq!(encode_coap_uint(256), vec![0x01, 0x00]);
+        assert_eq!(encode_coap_uint(0xFFFFFFFF), vec![0xFF, 0xFF, 0xFF, 0xFF]);
+        #[cfg(target_pointer_width = "64")]
+        {
+            assert_eq!(encode_coap_uint(0x100000000), vec![0xFF, 0xFF, 0xFF, 0xFF]);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_observe_empty_resource_includes_size2() {
+        let mut observer = Observer::new();
+        let path = "empty";
+        let addr: SocketAddr = "127.0.0.1:5003".parse().unwrap();
+
+        // Create an empty resource via PUT
+        let empty_payload = vec![];
+        let mut put_req = CoapRequest::<SocketAddr>::new();
+        put_req.set_method(Method::Put);
+        put_req.set_path(path);
+        put_req.message.payload = empty_payload.clone();
+        put_req.source = Some(addr);
+        observer
+            .request_handler(&mut put_req, Arc::new(MockResponder::new(addr)))
+            .await;
+
+        // Register to observe the empty resource
+        let mut reg_req = CoapRequest::<SocketAddr>::new();
+        reg_req.set_method(Method::Get);
+        reg_req.set_path(path);
+        reg_req.set_observe_flag(ObserveOption::Register);
+        reg_req.source = Some(addr);
+        reg_req.response = Some(CoapResponse {
+            message: Packet::new(),
+        });
+        let responder = Arc::new(MockResponder::new(addr));
+        observer
+            .request_handler(&mut reg_req, responder.clone())
+            .await;
+
+        let resp_bytes = responder.get_last_sent().await.unwrap();
+        let resp_pkt = Packet::from_bytes(&resp_bytes).unwrap();
+
+        // Verify Size2 option is present and value is 0
+        let size2_opt = resp_pkt.get_first_option(CoapOption::Size2);
+        assert!(
+            size2_opt.is_some(),
+            "Size2 option missing for empty resource"
+        );
+        let size2_val = decode_uint(size2_opt.unwrap());
+        assert_eq!(size2_val, 0, "Size2 value should be 0 for empty payload");
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,7 @@
-use std::{net::{IpAddr, SocketAddr}, str::FromStr};
+use std::{
+    net::{IpAddr, SocketAddr},
+    str::FromStr,
+};
 
 pub use coap_lite::{
     CoapOption, CoapRequest, MessageClass, MessageType, ObserveOption, Packet,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use coap_lite::{BlockHandler, BlockHandlerConfig, CoapRequest, CoapResponse, Packet};
+use coap_lite::{BlockHandler, BlockHandlerConfig, CoapOption, CoapRequest, CoapResponse, Packet};
 use log::debug;
 use std::{
     future::Future,
@@ -331,13 +331,32 @@ impl ServerCoapState {
     }
 
     pub async fn intercept_response(&mut self, request: &mut CoapRequest<SocketAddr>) {
-        match self.block_handler.intercept_response(request) {
-            Err(err) => {
-                let _ = request.apply_from_error(err);
+        let resource_path = request.get_path();
+
+        let is_block_fetch_for_observer = request.message.get_option(CoapOption::Block2).is_some()
+            && request.message.get_option(CoapOption::Observe).is_none()
+            && request.source.is_some()
+            && self
+                .observer
+                .is_observing(&request.source.unwrap(), &resource_path);
+
+        if is_block_fetch_for_observer {
+            if let Some((payload, etag)) =
+                self.observer.get_resource_payload_and_etag(&resource_path)
+            {
+                if let Some(ref mut response) = request.response {
+                    response.message.payload = payload.to_vec();
+                    response.message.clear_option(CoapOption::ETag);
+                    response.message.add_option(CoapOption::ETag, etag);
+                }
             }
-            _ => {}
+        }
+
+        if let Err(err) = self.block_handler.intercept_response(request) {
+            let _ = request.apply_from_error(err);
         }
     }
+
     pub fn new() -> Self {
         Self {
             observer: Observer::new(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,7 +18,7 @@ use tokio::{
     task::JoinHandle,
 };
 
-use crate::observer::Observer;
+use crate::observer::{encode_coap_uint, Observer};
 
 #[derive(Debug)]
 pub enum CoAPServerError {
@@ -348,6 +348,11 @@ impl ServerCoapState {
                     response.message.payload = payload.to_vec();
                     response.message.clear_option(CoapOption::ETag);
                     response.message.add_option(CoapOption::ETag, etag);
+                    // Prevent duplicate Size2 options, clear first.
+                    response.message.clear_option(CoapOption::Size2);
+                    response
+                        .message
+                        .add_option(CoapOption::Size2, encode_coap_uint(payload.len()));
                 }
             }
         }


### PR DESCRIPTION
This PR implements **RFC 7959 §2.6**, adding full support for observing large resources that require block-wise transfers.

### Motivation
Previously, if an observed resource's payload exceeded the payload limit or the client's preferred block size, the server would attempt to send the entire payload in a single notification. This violated RFC 7959 and often resulted in UDP packet fragmentation or transmission failures.

### Key Changes
**Server-side (`observer.rs`, `server.rs`):**
- The server records the client's preferred block size during Observe registration (only if the client explicitly requests the `Block2` option, ensuring backward compatibility).
- Upon resource change, the server sends a notification containing **only the first block**, including the `Block2` and `ETag` options.
- The server intercepts subsequent GET requests for remaining blocks, using a shared payload snapshot (`Arc<Vec<u8>>`) and ETag to guarantee that all blocks originate from the exact same resource version.

**Client-side (`client.rs`):**
- When receiving a notification with `Block2 (more=true)`, the client automatically fetches the remaining blocks using standard GET requests.
- Implements **per-block ETag validation**: if the resource changes mid-transfer (ETag mismatch), the client immediately aborts the current transfer and waits for the next notification, preventing partial/corrupted payload assembly.

**Compatibility & Performance:**
- **Strict compliance:** The server never adds the critical `Block2` option unless the client explicitly requested it in the registration. This ensures seamless operation with older clients that do not support block-wise transfers.
- **Memory optimization:** Resource payloads are stored in `Arc<Vec<u8>>` to avoid deep cloning large data.

**Testing:**
- Added new integration tests: continuous large-resource updates, block size boundaries, independent client block size preferences, cancellation, and backward-compatible fallback.
- Added a server unit test verifying block size boundaries and multi-client preference isolation.

**Note:** Cancellation of observation (`ObserveMessage::Terminate`) is best-effort over UDP; clients should be prepared to handle occasional extra notifications if the deregistration message is lost.
