### PR TITLE
reduce dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ edition = "2021"
 url = "^2.5"
 log = "^0.4"
 regex = "^1.5"
-tokio = { version = "^1.32", default-features = false }
+tokio = { version = "^1.32", default-features = false, features = [
+    "sync",
+    "time",
+] }
 tokio-stream = { version = "^0.1", features = [
     "time",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,10 @@ edition = "2021"
 url = "^2.5"
 log = "^0.4"
 regex = "^1.5"
-tokio = { version = "^1.32", features = ["full"] }
-tokio-util = { version = "^0.7", features = ["codec", "net"] }
-tokio-stream = { version = "^0.1", features = ["time"] }
+tokio = { version = "^1.32", default-features = false }
+tokio-stream = { version = "^0.1", features = [
+    "time",
+] }
 futures = "^0.3"
 coap-lite = "0.13.2"
 async-trait = "0.1.74"
@@ -36,7 +37,7 @@ sec1 = { version = "0.7.3", features = [
 rand = "0.9.0"
 
 # dependencies for extractor
-percent-encoding = { version = "2.1", optional = true}
+percent-encoding = { version = "2.1", optional = true }
 serde = { version = "1.0", optional = true }
 serde_html_form = { version = "0.2.7", optional = true }
 serde_path_to_error = { version = "0.1.9", optional = true }
@@ -68,3 +69,4 @@ router = [
 quickcheck = "1.0"
 socket2 = "0.5"
 tokio-test = "0.4.4"
+tokio = { version = "^1.32", features = ["full"] }


### PR DESCRIPTION
Hey, 
I want to use your crate on a esp32 with tokio. But on the esp32 there is no siginfo_t, SIGKILL, SA_SIGINFO, sa_sigaction, so I can't use all features of tokio. In your crate you use the "full" features of tokio, but you only use `sync` and `time` as far as I could see. So I changed the features list and moved the full to dev-dependencies.

I also removed tokio-util, couldn't see where it is used.