### PR TITLE
added missing macros to tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ regex = "^1.5"
 tokio = { version = "^1.32", default-features = false, features = [
     "sync",
     "time",
+    "macros"
 ] }
 tokio-stream = { version = "^0.1", features = [
     "time",


### PR DESCRIPTION
Somehow it build before, but now when I build it from 0.28.0 it failes. It makes sense, since the feature is required. Can't figure out why it worked before. 
Sorry for the mistake, but this feature flag is required because you use the `select` macro of tokio